### PR TITLE
Row: Fixed getting row Id using internal value getter

### DIFF
--- a/src/Row.php
+++ b/src/Row.php
@@ -46,8 +46,7 @@ class Row extends Nette\Object
 		$this->datagrid = $datagrid;
 		$this->item = $item;
 		$this->primary_key = $primary_key;
-
-		$this->id = is_object($item) ? $item->{$primary_key} : $item[$primary_key];
+		$this->id = $this->getValue($primary_key);
 	}
 
 


### PR DESCRIPTION
This is a huge problem as `$id` property of my entity is private so getter method needs to be used.