### PR TITLE
Added possibility to have grid in component and call its handlers in addAction

### DIFF
--- a/src/Column/Action.php
+++ b/src/Column/Action.php
@@ -94,11 +94,11 @@ class Action extends Column
 		}
 
 		$a = Html::el('a')
-			->href($this->grid->getPresenter()->link($this->href, $this->getItemParams($row)));
+			->href($this->grid->getParent()->link($this->href, $this->getItemParams($row)));
 
 		if ($this->icon) {
 			$a->add(Html::el('span')->class(DataGrid::$icon_prefix.$this->icon));
-			
+
 			if (strlen($this->name)) {
 				$a->add('&nbsp;');
 			}

--- a/src/Column/Action.php
+++ b/src/Column/Action.php
@@ -10,6 +10,7 @@ namespace Ublaboo\DataGrid\Column;
 
 use Nette\Utils\Html;
 use Ublaboo\DataGrid\DataGrid;
+use Ublaboo\DataGrid\DataGridHasToBeAttachedToPresenterComponentException;
 use Ublaboo\DataGrid\Row;
 
 class Action extends Column
@@ -93,8 +94,14 @@ class Action extends Column
 			}
 		}
 
+		try {
+			$parent = $this->grid->getParent();
+		} catch (DataGridHasToBeAttachedToPresenterComponentException $e) {
+			$parent = $this->grid->getPresenter();
+		}
+
 		$a = Html::el('a')
-			->href($this->grid->getParent()->link($this->href, $this->getItemParams($row)));
+			->href($parent->link($this->href, $this->getItemParams($row)));
 
 		if ($this->icon) {
 			$a->add(Html::el('span')->class(DataGrid::$icon_prefix.$this->icon));

--- a/src/DataGrid.php
+++ b/src/DataGrid.php
@@ -9,6 +9,7 @@
 namespace Ublaboo\DataGrid;
 
 use Nette;
+use Nette\Application\UI\PresenterComponent;
 use Ublaboo\DataGrid\Utils\ArraysHelper;
 use Nette\Application\UI\Form;
 
@@ -1915,6 +1916,23 @@ class DataGrid extends Nette\Application\UI\Control
 		}
 
 		return $this->columns;
+	}
+
+
+
+	/**
+	 * @return PresenterComponent
+	 */
+	public function getParent()
+	{
+		$parent = parent::getParent();
+		if (!$parent instanceof PresenterComponent) {
+			throw new DataGridHasToBeAttachedToPresenterComponentException(
+				"DataGrid is attached to: '" . get_class($parent) . "', but instance of PresenterComponent is needed."
+			);
+		}
+
+		return $parent;
 	}
 
 }

--- a/src/exceptions.php
+++ b/src/exceptions.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Ublaboo\DataGrid;
+
+class DataGridHasToBeAttachedToPresenterComponentException extends \LogicException
+{
+
+}


### PR DESCRIPTION
problem:

```php
class XyzGridControl extends BaseControl
{

     ....
     $grid->addAction('confirm', 'Schválit', 'confirm!');
}
```
causes: `Unknown signal 'confirm', missing handler XyzModule\XyzPresenter::handleconfirm()`

----

Question is: Can this change broke something? 