### PR TITLE
Added some black magic for getting correct translator

### DIFF
--- a/src/DataGrid.php
+++ b/src/DataGrid.php
@@ -1595,7 +1595,15 @@ class DataGrid extends Nette\Application\UI\Control
 	public function getTranslator()
 	{
 		if (!$this->translator) {
-			$this->translator = new Localization\SimpleTranslator;
+			$parent = $this->getParent();
+			if (
+				$parent->getReflection()->hasMethod('getTranslator')
+				&& ($translator = $parent->getTranslator()) instanceof  Nette\Localization\ITranslator
+			) {
+				$this->translator = $translator;
+			} else {
+				$this->translator = new Localization\SimpleTranslator;
+			}
 		}
 
 		return $this->translator;


### PR DESCRIPTION
I do not like this, but I have no idea how make this clean-way.

![](http://i.imgur.com/mvoLoJ3.gif)

What do you think?

The problem is that you have to write:
```php
$grid = new DataGrid();
$grid->setTranslator($this->getTranslator());
```

Any time in order to have correct translator instance in DataGrid component.

