### PR TITLE
Method orderBy used in DoctrineDataSource::sort changed to addOrderBy

### DIFF
--- a/src/DataSource/DoctrineDataSource.php
+++ b/src/DataSource/DoctrineDataSource.php
@@ -313,7 +313,7 @@ class DoctrineDataSource implements IDataSource
 
 		if ($sorting) {
 			foreach ($sorting as $column => $sort) {
-				$this->data_source->orderBy("{$alias}.{$column}", $sort);
+				$this->data_source->addOrderBy("{$alias}.{$column}", $sort);
 			}
 		} else {
 			/**


### PR DESCRIPTION
Hi,
with doctrine datasource, if I use $grid->setDefaultSort(['foo1' => 'ASC', 'foo2' => DESC]) only last item in array is used for sorting. I found out that in DoctrineDataSource::sort method is orderBy but it should be addOrderBy. Only hope that this not break anything else :-)