### PR TITLE
Do not set session if no session avalable (not attached to presenter)

### DIFF
--- a/src/DataGrid.php
+++ b/src/DataGrid.php
@@ -200,7 +200,7 @@ class DataGrid extends Nette\Application\UI\Control
 	private $refresh_url = TRUE;
 
 	/**
-	 * @var Nette\Http\SessionSection
+	 * @var Nette\Http\SessionSection|NULL
 	 */
 	private $grid_session;
 
@@ -1781,7 +1781,7 @@ class DataGrid extends Nette\Application\UI\Control
 	 */
 	public function saveSessionData($key, $value)
 	{
-		if ($this->remember_state) {
+		if ($this->remember_state && $this->grid_session !== NULL) {
 			$this->grid_session->{$key} = $value;
 		}
 	}


### PR DESCRIPTION
This is a little bit hotfix. There should be some complex solution of problem, when you create Grid and you do not have attached it to presented via constructor. Some `injectSession` maybe?

Fixes : #92