### PR TITLE
OnColumnAddCallback

### DIFF
--- a/src/DataGrid.php
+++ b/src/DataGrid.php
@@ -227,6 +227,9 @@ class DataGrid extends Nette\Application\UI\Control
 	 */
 	protected $can_hide_columns = FALSE;
 
+	/** @var callable[] */
+	public $onColumnAdd;
+
 
 	/**
 	 * @param Nette\ComponentModel\IContainer|NULL $parent
@@ -611,7 +614,7 @@ class DataGrid extends Nette\Application\UI\Control
 		$this->addColumnCheck($key);
 		$column = $column ?: $key;
 
-		return $this->columns[$key] = new Column\ColumnText($column, $name);
+		return $this->addColumn($key, new Column\ColumnText($column, $name));
 	}
 
 
@@ -632,7 +635,7 @@ class DataGrid extends Nette\Application\UI\Control
 			$params = [$this->primary_key];
 		}
 
-		return $this->columns[$key] = new Column\ColumnLink($this, $column, $name, $href, $params);
+		return $this->addColumn($key, new Column\ColumnLink($this, $column, $name, $href, $params));
 	}
 
 
@@ -648,7 +651,7 @@ class DataGrid extends Nette\Application\UI\Control
 		$this->addColumnCheck($key);
 		$column = $column ?: $key;
 
-		return $this->columns[$key] = new Column\ColumnNumber($column, $name);
+		return $this->addColumn($key, new Column\ColumnNumber($column, $name));
 	}
 
 
@@ -664,7 +667,19 @@ class DataGrid extends Nette\Application\UI\Control
 		$this->addColumnCheck($key);
 		$column = $column ?: $key;
 
-		return $this->columns[$key] = new Column\ColumnDateTime($column, $name);
+		return $this->addColumn($key, new Column\ColumnDateTime($column, $name));
+	}
+
+
+	/**
+	 * @param string $key
+	 * @param Column\Column $column
+	 * @return Column\Column
+	 */
+	protected function addColumn($key, Column\Column $column)
+	{
+		$this->onColumnAdd($key, $column);
+		return $this->columns[$key] = $column;
 	}
 
 

--- a/tests/Cases/OnColumnAddCallbackTest.phpt
+++ b/tests/Cases/OnColumnAddCallbackTest.phpt
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * TEST: OnColumnAddCallbackTest
+ * @testCase Ublaboo\DataGrid\Tests\Cases\OnColumnAddCallbackTest
+ */
+
+namespace Ublaboo\DataGrid\Tests\Cases;
+
+use Tester;
+use Ublaboo;
+
+require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../Files/XTestingDataGridFactory.php';
+
+
+class OnColumnAddCallbackTest extends Tester\TestCase
+{
+
+	/**
+	 * @var Ublaboo\DataGrid\DataGrid
+	 */
+	private $grid;
+
+
+	public function setUp()
+	{
+		$factory = new Ublaboo\DataGrid\Tests\Files\XTestingDataGridFactory;
+		$this->grid = $factory->createXTestingDataGrid();
+	}
+
+
+	public function testSetSortable()
+	{
+		$this->grid->onColumnAdd[] = function($key, Ublaboo\DataGrid\Column\Column $column) {
+			$column->setSortable();
+		};
+
+		$columnText = $this->grid->addColumnText('text', 'textName');
+		$columnNumber = $this->grid->addColumnNumber('number', 'numberName');
+		$columnDateTime = $this->grid->addColumnDateTime('dateTime', 'dateTimeName');
+
+		$columnTextNotSortable = $this->grid->addColumnText('textNotSortable', 'textName')
+			->setSortable(FALSE);
+
+		Tester\Assert::true($columnText->isSortable());
+		Tester\Assert::true($columnNumber->isSortable());
+		Tester\Assert::true($columnDateTime->isSortable());
+
+		Tester\Assert::false($columnTextNotSortable->isSortable());
+	}
+
+}
+
+$test = new OnColumnAddCallbackTest();
+$test->run();


### PR DESCRIPTION
- add $onColumnAdd callback called when you add column of any type to datagrid

I need call event when I adding columns in my grid. Is there any other way to do it? If not can you plese merge it?