### PR TITLE
Allow arbitrary LazyLink for Action button

### DIFF
--- a/src/Column/Column.php
+++ b/src/Column/Column.php
@@ -581,6 +581,14 @@ abstract class Column extends FilterableColumn
 	 */
 	protected function createLink($href, $params)
 	{
+		if ($href instanceof \Nette\Application\UI\Link) {
+			foreach ($params as $key => $value) {
+				$href->setParameter($key, $value);
+			}
+
+			return $href;
+		}
+
 		try {
 			$parent = $this->grid->getParent();
 


### PR DESCRIPTION
And probably every where else too if `Column::createLink` is used.