### PR TITLE
Unite reset filter string when there are no rows found

### DIFF
--- a/src/templates/datagrid.latte
+++ b/src/templates/datagrid.latte
@@ -258,7 +258,7 @@
 							<tr n:if="!$rows">
 								<td colspan="{$control->getColumnsCount()}">
 									{if $filter_active}
-										{_'ublaboo_datagrid.no_item_found'} <a class="link ajax" n:href="resetFilter!">{_'ublaboo_datagrid.here'}</a>.
+										{_'ublaboo_datagrid.no_item_found'} <a class="link ajax" n:href="resetFilter!">{_'ublaboo_datagrid.reset_filter'}</a>.
 									{else}
 										{_'ublaboo_datagrid.no_item_found'}
 									{/if}


### PR DESCRIPTION
Was there a reason for that `ublaboo_datagrid.here` anchor?