### PR TITLE
Use correct translation string

### DIFF
--- a/src/templates/datagrid.latte
+++ b/src/templates/datagrid.latte
@@ -258,7 +258,7 @@
 							<tr n:if="!$rows">
 								<td colspan="{$control->getColumnsCount()}">
 									{if $filter_active}
-										{_'ublaboo_datagrid.no_item_found'} <a class="link ajax" n:href="resetFilter!">{_'ublaboo_datagrid.here'}</a>.
+										{_'ublaboo_datagrid.no_item_found_reset'} <a class="link ajax" n:href="resetFilter!">{_'ublaboo_datagrid.here'}</a>.
 									{else}
 										{_'ublaboo_datagrid.no_item_found'}
 									{/if}


### PR DESCRIPTION
The string `ublaboo_datagrid.no_item_found_reset` wasn't used anywhere so I guess this is where it belongs :-)