### PR TITLE
Support for components from callback

### DIFF
--- a/src/DataGrid.php
+++ b/src/DataGrid.php
@@ -77,6 +77,11 @@ class DataGrid extends Nette\Application\UI\Control
 
 	/**
 	 * @var array
+	 */
+	public $components = [];
+
+	/**
+	 * @var array
 	 * @persistent
 	 */
 	public $filter = [];
@@ -2164,6 +2169,18 @@ class DataGrid extends Nette\Application\UI\Control
 		}
 
 		return $this->items_detail;
+	}
+
+
+	/**
+	 * Factory for components from callback
+	 * @return Nette\ComponentModel\IComponent
+	 */
+	protected function createComponent($name)
+	{
+		return (isset($this->components[$name]))
+			? $this->components[$name]()
+			: parent::createComponent($name);
 	}
 
 


### PR DESCRIPTION
With this feature it's possible attach component, for example for *item detail*.

```php
$grid->components['orderDetail'] = function () use ($grid) {
	return $this->orderDetailFactory->create();
};
```

Now it's possible use in `detail.latte`:

```latte
{control orderDetail $item->id}
```