### PR TITLE
Setting a new translator to datagrid instance causes the translator t…

### DIFF
--- a/src/Components/DataGridPaginator/DataGridPaginator.php
+++ b/src/Components/DataGridPaginator/DataGridPaginator.php
@@ -67,6 +67,13 @@ class DataGridPaginator extends Nette\Application\UI\Control
 	}
 
 
+	public function setTranslator(Nette\Localization\ITranslator $translator)
+	{
+		$this->translator = $translator;
+		return $this;
+	}
+
+
 	/**
 	 * @return Nette\Utils\Paginator
 	 */

--- a/src/DataGrid.php
+++ b/src/DataGrid.php
@@ -1966,6 +1966,12 @@ class DataGrid extends Nette\Application\UI\Control
 	{
 		$this->translator = $translator;
 
+		foreach ($this->getComponents(true) as $component) {
+			if (method_exists($component, 'setTranslator')) {
+				$component->setTranslator($translator);
+			}
+		}
+
 		return $this;
 	}
 


### PR DESCRIPTION
…o be set to all sub-components that implement method 'setTranslator'. Solves #184