### PR TITLE
Add button Show default columns

### DIFF
--- a/src/DataGrid.php
+++ b/src/DataGrid.php
@@ -1837,6 +1837,21 @@ class DataGrid extends Nette\Application\UI\Control
 
 
 	/**
+	 * Tell datagrid to display default columns
+	 * @return void
+	 */
+	public function handleShowDefaultColumns()
+	{
+		$this->deleteSesssionData('_grid_hidden_columns');
+		$this->saveSessionData('_grid_hidden_columns_manipulated', FALSE);
+
+		$this->redrawControl();
+
+		$this->onRedraw();
+	}
+
+
+	/**
 	 * Reveal particular column
 	 * @param  string $column
 	 * @return void

--- a/src/Localization/SimpleTranslator.php
+++ b/src/Localization/SimpleTranslator.php
@@ -26,6 +26,7 @@ class SimpleTranslator extends Nette\Object implements Nette\Localization\ITrans
 		'ublaboo_datagrid.reset_filter' => 'Reset filter',
 		'ublaboo_datagrid.group_actions' => 'Group actions',
 		'ublaboo_datagrid.show_all_columns' => 'Show all columns',
+		'ublaboo_datagrid.show_default_columns' => 'Show default columns',
 		'ublaboo_datagrid.hide_column' => 'Hide column',
 		'ublaboo_datagrid.action' => 'Action',
 		'ublaboo_datagrid.previous' => 'Previous',

--- a/src/templates/datagrid.latte
+++ b/src/templates/datagrid.latte
@@ -102,6 +102,9 @@
 										<li>
 											<a n:href="showAllColumns!" class="ajax"><i class="{$icon_prefix}eye"></i> {_'ublaboo_datagrid.show_all_columns'}</a>
 										</li>
+										<li>
+											<a n:href="showDefaultColumns!" class="ajax"><i class="{$icon_prefix}repeat"></i> {_'ublaboo_datagrid.show_default_columns'}</a>
+										</li>
 									</ul>
 								</div>
 							</span>


### PR DESCRIPTION
I have very big grid - with 50 hideable columns. When I click to *Show all columns*, it's very lengthy manual click on every column for setting *default view*.
This PR add *Show default columns* button.
![image](https://cloud.githubusercontent.com/assets/1110294/14826381/e7b39e54-0bdd-11e6-86be-d3d7efd323dd.png)