### PR TITLE
Hide group action stuff if there's no group action available on rows

### DIFF
--- a/src/DataGrid.php
+++ b/src/DataGrid.php
@@ -361,8 +361,14 @@ class DataGrid extends Nette\Application\UI\Control
 
 		$callback = $this->rowCallback ?: NULL;
 
+		$hasGroupActionOnRows = false;
+
 		foreach ($items as $item) {
 			$rows[] = $row = new Row($this, $item, $this->getPrimaryKey());
+
+			if(!$hasGroupActionOnRows && $row->hasGroupAction()){
+				$hasGroupActionOnRows = true;
+			}
 
 			if ($callback) {
 				$callback($item, $row->getControl());
@@ -372,7 +378,7 @@ class DataGrid extends Nette\Application\UI\Control
 		if ($this->isTreeView()) {
 			$this->template->add('tree_view_has_children_column', $this->tree_view_has_children_column);
 		}
-
+		$this->template->add('hasGroupActionOnRows', $hasGroupActionOnRows);
 		$this->template->add('rows', $rows);
 
 		$this->template->add('columns', $this->getColumns());
@@ -2271,7 +2277,7 @@ class DataGrid extends Nette\Application\UI\Control
 
 
 	/**
-	 * @param callable $callable_set_container 
+	 * @param callable $callable_set_container
 	 * @return static
 	 */
 	public function setItemsDetailForm(callable $callable_set_container)
@@ -2535,7 +2541,7 @@ class DataGrid extends Nette\Application\UI\Control
 		}
 
 		$hidden_columns = $this->getSessionData('_grid_hidden_columns', []);
-		
+
 		foreach ($hidden_columns as $column) {
 			if (!empty($this->columns[$column])) {
 				$this->columns_visibility[$column] = [

--- a/src/templates/datagrid.latte
+++ b/src/templates/datagrid.latte
@@ -48,9 +48,9 @@
 			{/if}
 			<table class="{block table-class}table table-hover table-striped table-bordered{/block}" n:snippet="table" n:block="data">
 				<thead>
-					<tr class="row-group-actions" n:if="$control->hasGroupActions() || $exports || $control->canHideColumns() || $inlineAdd">
+					<tr class="row-group-actions" n:if="$hasGroupActionOnRows || $exports || $control->canHideColumns() || $inlineAdd">
 						<th colspan="{$control->getColumnsCount()}" class="form-inline">
-							{if $control->hasGroupActions()}
+							{if $hasGroupActionOnRows}
 								{block group_actions}
 									{_'ublaboo_datagrid.group_actions'}:
 									{foreach $filter['group_action']->getControls() as $form_control}
@@ -108,7 +108,7 @@
 						</th>
 					</tr>
 					<tr n:block="header">
-						<th n:if="$control->hasGroupActions()" rowspan="2" class="col-checkbox">
+						<th n:if="$hasGroupActionOnRows" rowspan="2" class="col-checkbox">
 							<input n:class="$control->useHappyComponents() ? 'happy gray-border' , primary" name="toggle-all" type="checkbox" data-check="{!$control->getName()}" data-check-all="{$control->getName()}">
 						</th>
 						{foreach $columns as $key => $column}
@@ -194,7 +194,7 @@
 									{? $inlineEdit->onSetDefaults($filter['inline_edit'], $item); }
 
 									<tr data-id="{$row->getId()}" n:snippet="item-{$row->getId()}" n:class="$row->getControlClass()">
-										<td n:if="$control->hasGroupActions()" class="col-checkbox"></td>
+										<td n:if="$hasGroupActionOnRows" class="col-checkbox"></td>
 
 										{foreach $columns as $key => $column}
 											{var $col = 'col-' . $key}
@@ -217,7 +217,7 @@
 									</tr>
 								{else}
 									<tr data-id="{$row->getId()}" n:snippet="item-{$row->getId()}" n:class="$row->getControlClass()">
-										<td n:if="$control->hasGroupActions()" class="col-checkbox">
+										<td n:if="$hasGroupActionOnRows" class="col-checkbox">
 											{if $row->hasGroupAction()}
 												<input n:class="$control->useHappyComponents() ? 'happy gray-border' , primary" type="checkbox" data-check="{!$control->getName()}" data-check-all-{!$control->getName()} name="group_action_item[{$row->getId()}]">
 											{/if}
@@ -370,7 +370,7 @@
 	{? $inlineAdd->onSetDefaults($filter['inline_add']); }
 
 	<tr class="datagrid-row-inline-add datagrid-row-inline-add-hidden">
-		<td n:if="$control->hasGroupActions()" class="col-checkbox"></td>
+		<td n:if="$hasGroupActionOnRows" class="col-checkbox"></td>
 
 		{foreach $columns as $key => $column}
 			{var $col = 'col-' . $key}


### PR DESCRIPTION
I think we should not have Group actions select box, and select all checkbox if group actions are enabled, but in all displayed rows there's no group action available. So I created this pull request, I'm very new to this datagrid, so it's highly possible that I overseen something.