### PR TITLE
Fix error: Column in where clause is ambiguous

### DIFF
--- a/src/DataSource/NetteDatabaseTableDataSource.php
+++ b/src/DataSource/NetteDatabaseTableDataSource.php
@@ -82,6 +82,12 @@ class NetteDatabaseTableDataSource extends FilterableDataSource implements IData
 	 */
 	public function filterOne(array $condition)
 	{
+		foreach ($condition as $col => $value) {
+			if (strpos($col, '.') === FALSE) {
+				$condition[$this->data_source->getName() . '.' . $col] = $value;
+				unset($condition[$col]);
+			}
+		}
 		$this->data_source->where($condition)->limit(1);
 
 		return $this;


### PR DESCRIPTION
Fix empty table name for columns, for example when I get one row for detail and datasource have JOIN.

![snimka obrazovky z 2016-05-10 23 45 04](https://cloud.githubusercontent.com/assets/1110294/15163574/80146f08-1709-11e6-9dad-95af56b2a8a5.png)
