### PR TITLE
Fixes sorting when database column is specified and is different name…

### DIFF
--- a/src/DataGrid.php
+++ b/src/DataGrid.php
@@ -1508,6 +1508,9 @@ class DataGrid extends Nette\Application\UI\Control
 		 */
 		if (empty($this->sort_callback) && !empty($this->sort)) {
 			foreach ($this->sort as $key => $order) {
+				if(!isset($this->columns[$key])){
+					continue;
+				}
 				$column = $this->getColumn($key);
 
 				if ($column && $column->isSortable() && is_callable($column->getSortableCallback())) {


### PR DESCRIPTION
If you set sorting by database column instead of column key (you have to when you have join query) and have remember state on grid when trying to get sessiong back it tries to read grid column which doesn't exist and you get exception

Code that reproduces this bug:
`
        $this->setDefaultSort(['column.id' => 'DESC']);
`
refresh the page 
and you'll get exception: "There is no column at key [$key] defined."