### PR TITLE
Export link lazy loading

### DIFF
--- a/src/DataGrid.php
+++ b/src/DataGrid.php
@@ -9,6 +9,7 @@
 namespace Ublaboo\DataGrid;
 
 use Nette;
+use Nette\Application\UI\Link;
 use Nette\Application\UI\PresenterComponent;
 use Ublaboo\DataGrid\Utils\ArraysHelper;
 use Nette\Application\UI\Form;
@@ -1589,7 +1590,7 @@ class DataGrid extends Nette\Application\UI\Control
 	{
 		$id = ($s = sizeof($this->exports)) ? ($s + 1) : 1;
 
-		$export->setLink($this->link('export!', ['id' => $id]));
+		$export->setLink(new Link($this, 'export!', ['id' => $id]));
 
 		return $this->exports[$id] = $export;
 	}
@@ -1598,7 +1599,7 @@ class DataGrid extends Nette\Application\UI\Control
 	public function resetExportsLinks()
 	{
 		foreach ($this->exports as $id => $export) {
-			$export->setLink($this->link('export!', ['id' => $id]));
+			$export->setLink(new Link($this, 'export!', ['id' => $id]));
 		}
 	}
 

--- a/tests/Cases/ExportLinkTest.phpt
+++ b/tests/Cases/ExportLinkTest.phpt
@@ -1,0 +1,32 @@
+<?php
+
+namespace Ublaboo\DataGrid\Tests\Cases;
+
+use Nette\Application\AbortException;
+use Tester\Assert;
+use Tester\TestCase,
+	Ublaboo;
+use Ublaboo\DataGrid\Tests\Files\XTestingDataGridFactory;
+
+
+
+require __DIR__ . '/../bootstrap.php';
+
+final class ExportLinkTest extends TestCase
+{
+
+	public function testExportLink()
+	{
+		$factory = new XTestingDataGridFactory;
+		$grid = $factory->createXTestingDataGrid('ExportTesting');
+		$grid->setDataSource([]);
+
+		Assert::exception(function () use ($grid) {
+			$grid->handleExport(1);
+		}, AbortException::class);
+	}
+
+}
+
+$test_case = new ExportLinkTest;
+$test_case->run();

--- a/tests/Files/ExportTestingPresenter.php
+++ b/tests/Files/ExportTestingPresenter.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Ublaboo\DataGrid\Tests\Files;
+
+use Nette;
+use Ublaboo\DataGrid\DataGrid;
+
+final class ExportTestingPresenter extends Nette\Application\UI\Presenter
+{
+
+	protected function createComponentGrid($name)
+	{
+		$grid = new DataGrid(NULL, $name);
+		$grid->addExportCsv('export', 'export.csv');
+
+		return $grid;
+	}
+
+}

--- a/tests/Files/XTestingDataGridFactory.php
+++ b/tests/Files/XTestingDataGridFactory.php
@@ -3,18 +3,17 @@
 namespace Ublaboo\DataGrid\Tests\Files;
 
 use Nette\Http,
-	Nette,
-	Ublaboo\DataGrid\DataGrid;
+	Nette;
 
 class XTestingDataGridFactory
 {
 
-	public function createXTestingDataGrid()
+	public function createXTestingDataGrid($presenterName = 'XTesting')
 	{
 		$presenterFactory = new Nette\Application\PresenterFactory;
 		$presenterFactory->setMapping(['*' => 'Ublaboo\DataGrid\Tests\Files\*Presenter']);
 
-		$presenter = $presenterFactory->createPresenter('XTesting');
+		$presenter = $presenterFactory->createPresenter($presenterName);
 
 		$url = new Http\UrlScript('localhost');
 		$request = new Http\Request($url);
@@ -23,7 +22,7 @@ class XTestingDataGridFactory
 
 		$presenter->injectPrimary(NULL, NULL, NULL, $request, $response, $session);
 
-		return new DataGrid($presenter, 'XTestingGrid');
+		return $presenter->getComponent('grid');
 	}
 
 }

--- a/tests/Files/XTestingPresenter.php
+++ b/tests/Files/XTestingPresenter.php
@@ -3,6 +3,7 @@
 namespace Ublaboo\DataGrid\Tests\Files;
 
 use Nette;
+use Ublaboo\DataGrid\DataGrid;
 
 final class XTestingPresenter extends Nette\Application\UI\Presenter
 {
@@ -28,6 +29,11 @@ final class XTestingPresenter extends Nette\Application\UI\Presenter
 	protected function createRequest($component, $destination, array $args, $mode)
 	{
 		return ucFirst($component->getName()) . $this->link($destination, $args);
+	}
+
+	protected function createComponentGrid($name)
+	{
+		return new DataGrid($this, $name);
 	}
 
 }


### PR DESCRIPTION
Component factories can not configure grid exports untill the grid is attached to a presenter. Adding an export invokes a link creation for which a presenter is used. As Nette [discourages](https://doc.nette.org/en/2.3/components#toc-delayed-composition) from knowing parents in component factories, this pull request fixes that issue.

Tests avoid that mentioned situation. A minimalistic change has been made to test the pull request.