### PR TITLE
Added missing $icon_prefix and the possibility to extend paginator template

### DIFF
--- a/src/Components/DataGridPaginator/DataGridPaginator.php
+++ b/src/Components/DataGridPaginator/DataGridPaginator.php
@@ -136,8 +136,8 @@ class DataGridPaginator extends Nette\Application\UI\Control
 			$this->template->add('paginator', $paginator);
 		}
 		
-		$this->template->icon_prefix = $this->icon_prefix;
-		$this->template->original_template = $this->getOriginalTemplateFile();
+		$this->template->add('icon_prefix', $this->icon_prefix);
+		$this->template->add('original_template', $this->getOriginalTemplateFile());
 		$this->template->setFile($this->getTemplateFile());
 		$this->template->render();
 	}

--- a/src/Components/DataGridPaginator/DataGridPaginator.php
+++ b/src/Components/DataGridPaginator/DataGridPaginator.php
@@ -32,15 +32,21 @@ class DataGridPaginator extends Nette\Application\UI\Control
 	 */
 	private $translator;
 
+	/**
+	 * @var  string
+	 */
+	private $icon_prefix;
 
 	public function __construct(
 		Nette\Localization\ITranslator $translator,
+		$icon_prefix = 'fa fa-',
 		IContainer $parent = NULL,
 		$name = NULL
 	) {
 		parent::__construct($parent, $name);
 
 		$this->translator = $translator;
+		$this->icon_prefix = $icon_prefix;
 	}
 
 
@@ -64,6 +70,16 @@ class DataGridPaginator extends Nette\Application\UI\Control
 	public function getTemplateFile()
 	{
 		return $this->template_file ?: __DIR__.'/templates/data_grid_paginator.latte';
+	}
+
+
+	/**
+	 * Get paginator original template file
+	 * @return string
+	 */
+	public function getOriginalTemplateFile()
+	{
+		return __DIR__.'/templates/data_grid_paginator.latte';
 	}
 
 
@@ -120,6 +136,8 @@ class DataGridPaginator extends Nette\Application\UI\Control
 			$this->template->add('paginator', $paginator);
 		}
 		
+		$this->template->icon_prefix = $this->icon_prefix;
+		$this->template->original_template = $this->getOriginalTemplateFile();
 		$this->template->setFile($this->getTemplateFile());
 		$this->template->render();
 	}

--- a/src/Components/DataGridPaginator/templates/data_grid_paginator.latte
+++ b/src/Components/DataGridPaginator/templates/data_grid_paginator.latte
@@ -1,18 +1,18 @@
 {*
  * @param Paginator $paginator
  * @param array     $steps
+ * @param string    $icon_prefix
  *}
 
 {var $link = [$control->getParent(), link]}
-{var $arrow_left = '<i class="fa fa-arrow-left"></i>'}
-{var $arrow_right = '<i class="fa fa-arrow-right"></i>'}
 
 <div n:if="$paginator->pageCount > 1">
 	{if $paginator->isFirst()}
-		<a class="first btn btn-sm btn-default disabled">{$arrow_left|noescape} {_'ublaboo_datagrid.previous'}</a>
+		<a class="first btn btn-sm btn-default disabled">
 	{else}
-		<a class="btn btn-sm btn-default ajax" href="{$link('page!', ['page' => $paginator->page - 1])}" rel="prev">{$arrow_left|noescape} {_'ublaboo_datagrid.previous'}</a>
+		<a class="btn btn-sm btn-default ajax" href="{$link('page!', ['page' => $paginator->page - 1])}" rel="prev">
 	{/if}
+	<i n:block = "icon-arrow-left" class="{$icon_prefix}arrow-left"></i> {_'ublaboo_datagrid.previous'}</a>
 
 	{foreach $steps as $step}
 		{if $step == $paginator->page}
@@ -25,8 +25,9 @@
 	{/foreach}
 
 	{if $paginator->isLast()}
-		<a class="first btn btn-sm btn-default disabled">{_'ublaboo_datagrid.next'} {$arrow_right|noescape}</a>
+		<a class="first btn btn-sm btn-default disabled">{_'ublaboo_datagrid.next'} 
 	{else}
-		<a class="btn btn-sm btn-default ajax" href="{$link('page!', ['page' => $paginator->page + 1])}" rel="next">{_'ublaboo_datagrid.next'} {$arrow_right|noescape}</a>
+		<a class="btn btn-sm btn-default ajax" href="{$link('page!', ['page' => $paginator->page + 1])}" rel="next">{_'ublaboo_datagrid.next'} 
 	{/if}
+	<i n:block = "icon-arrow-right" class="{$icon_prefix}arrow-right"></i></a>
 </div>

--- a/src/DataGrid.php
+++ b/src/DataGrid.php
@@ -2103,7 +2103,8 @@ class DataGrid extends Nette\Application\UI\Control
 		 * Init paginator
 		 */
 		$component = new Components\DataGridPaginator\DataGridPaginator(
-			$this->getTranslator()
+			$this->getTranslator(),
+			static::$icon_prefix
 		);
 		$paginator = $component->getPaginator();
 

--- a/src/templates/datagrid_filter_date.latte
+++ b/src/templates/datagrid_filter_date.latte
@@ -1,6 +1,7 @@
 {**
  * @param Filter                         $filter
  * @param Nette\Forms\Controls\TextInput $input
+ * @param string                         $icon_prefix       Icon prefix (fa fa-)
  *}
 
 {if $outer}
@@ -9,7 +10,7 @@
 		<div class="col-sm-9">
 			<div class="input-group">
 				{input $input}
-				<span class="input-group-addon"><span class="fa fa-calendar"></span></span>
+				<span class="input-group-addon"><span class="{$icon_prefix}calendar"></span></span>
 			</div>
 		</div>
 	</div>
@@ -17,7 +18,7 @@
 	<div class="form-inline">
 		<div class="input-group">
 			{input $input}
-			<span class="input-group-addon"><span class="fa fa-calendar"></span></span>
+			<span class="input-group-addon"><span class="{$icon_prefix}calendar"></span></span>
 		</div>
 	</div>
 {/if}

--- a/src/templates/datagrid_filter_daterange.latte
+++ b/src/templates/datagrid_filter_daterange.latte
@@ -1,6 +1,7 @@
 {**
  * @param Filter                $filter
  * @param Nette\Forms\Container $input
+ * @param string                $icon_prefix       Icon prefix (fa fa-)
  *}
 
 {var $container = $input}
@@ -11,14 +12,14 @@
 		<div class="col-sm-4">
 			<div class="input-group">
 				{input $container['from']}
-				<span class="input-group-addon"><span class="fa fa-calendar"></span></span>
+				<span class="input-group-addon"><span class="{$icon_prefix}calendar"></span></span>
 			</div>
 		</div>
 		{label $container['to'], class => 'filter-range-delimiter col-sm-1 control-label' /}
 		<div class="col-sm-4">
 			<div class="input-group">
 				{input $container['to']}
-				<span class="input-group-addon"><span class="fa fa-calendar"></span></span>
+				<span class="input-group-addon"><span class="{$icon_prefix}calendar"></span></span>
 			</div>
 		</div>
 	</div>
@@ -26,12 +27,12 @@
 	<div class="datagrid-col-filter-date-range form-inline">
 		<div class="input-group">
 			{input $container['from']}
-			<span class="input-group-addon input-group-addon-first"><span class="fa fa-calendar"></span></span>
+			<span class="input-group-addon input-group-addon-first"><span class="{$icon_prefix}calendar"></span></span>
 
 			<div class="input-group-addon datagrid-col-filter-datte-range-delimiter">-</div>
 
 			{input $container['to'], class => 'form-control input-sm datagrid-filter-date-range-last', data-autosubmit => TRUE}
-			<span class="input-group-addon"><span class="fa fa-calendar"></span></span>
+			<span class="input-group-addon"><span class="{$icon_prefix}calendar"></span></span>
 		</div>
 	</div>
 {/if}

--- a/src/templates/datagrid_tree.latte
+++ b/src/templates/datagrid_tree.latte
@@ -122,7 +122,7 @@
 								{/foreach}
 
 								<span class="handle-sort btn btn-xs btn-default" n:if="$control->isSortable()">
-									<i class="{$icon_prefix}arrows"></i>
+									<i n:block = "icon-arrows" class="{$icon_prefix}arrows"></i>
 								</span>
 							</div>
 						</div>


### PR DESCRIPTION
Paginator template now can be extended to overwrite `icon-arrow-left` and `icon-arrow-right` blocks using `$grid->getPaginator()->setTemplateFile(__DIR__ . '/custom_datagrid_paginator_template.latte');`

Also some missing n:blocks for icons were added (date filter & tree view)