### PR TITLE
Changed DataMode.phpl to first call getData() before getCount()

### DIFF
--- a/src/DataModel.php
+++ b/src/DataModel.php
@@ -111,14 +111,15 @@ class DataModel
 		 */
 		if ($paginator_component) {
 			$paginator = $paginator_component->getPaginator();
-			$paginator->setItemCount($this->data_source->getCount());
 
 			$this->data_source->sort($sorting)->limit(
 				$paginator->getOffset(),
 				$paginator->getItemsPerPage()
 			);
 
-			return $this->data_source->getData();
+			$data = $this->data_source->getData();
+			$paginator->setItemCount($this->data_source->getCount());
+			return $data;
 		}
 
 		return $this->data_source->sort($sorting)->getData();


### PR DESCRIPTION
The grid does always know what page is currently set and what is the item-per-page count, right? Therefore we can tell the datasource this (`limit(offset, itemsperpage)`) before asking for getCount().

I did test it on my grids and it worked well, you think this could work or it could break something?