### PR TITLE
Filter DataSource:  \DateTime check when using  \DateTime::createFromFormat()

### DIFF
--- a/src/DataSource/ArrayDataSource.php
+++ b/src/DataSource/ArrayDataSource.php
@@ -230,6 +230,10 @@ class ArrayDataSource implements IDataSource
 
 		if ($values['from'] !== NULL && $values['from'] !== '') {
 			$date_from = \DateTime::createFromFormat($format, $values['from']);
+			if (!($date_from instanceof \DateTime)) {
+				/** Date given is not in valid format */
+				return FALSE;
+			}
 			$date_from->setTime(0, 0, 0);
 
 			if (!($row_value instanceof \DateTime)) {
@@ -253,6 +257,10 @@ class ArrayDataSource implements IDataSource
 
 		if ($values['to'] !== NULL && $values['to'] !== '') {
 			$date_to = \DateTime::createFromFormat($format, $values['to']);
+			if (!($date_to instanceof \DateTime)) {
+				/** Date given is not in valid format */
+				return FALSE;
+			}
 			$date_to->setTime(23, 59, 59);
 
 			if (!($row_value instanceof \DateTime)) {
@@ -281,7 +289,7 @@ class ArrayDataSource implements IDataSource
 	/**
 	 * Apply fitler date and tell whether row value matches or not
 	 * @param  mixed  $row
-	 * @param  Filter $filter
+	 * @param  FilterDate $filter
 	 * @return mixed
 	 */
 	protected function applyFilterDate($row, FilterDate $filter)
@@ -293,6 +301,11 @@ class ArrayDataSource implements IDataSource
 			$row_value = $row[$column];
 
 			$date = \DateTime::createFromFormat($format, $value);
+
+			if (!($date instanceof \DateTime)) {
+				/** Date given is not in valid format */
+				return FALSE;
+			}
 
 			if (!($row_value instanceof \DateTime)) {
 				/**

--- a/src/DataSource/DibiFluentDataSource.php
+++ b/src/DataSource/DibiFluentDataSource.php
@@ -94,7 +94,9 @@ class DibiFluentDataSource extends FilterableDataSource implements IDataSource
 
 		$date = \DateTime::createFromFormat($filter->getPhpFormat(), $conditions[$filter->getColumn()]);
 
-		$this->data_source->where('DATE(%n) = ?', $filter->getColumn(), $date->format('Y-m-d'));
+		if ($date instanceof \DateTime) {
+			$this->data_source->where('DATE(%n) = ?', $filter->getColumn(), $date->format('Y-m-d'));
+		}
 	}
 
 
@@ -112,16 +114,20 @@ class DibiFluentDataSource extends FilterableDataSource implements IDataSource
 
 		if ($value_from) {
 			$date_from = \DateTime::createFromFormat($filter->getPhpFormat(), $value_from);
-			$date_from->setTime(0, 0, 0);
+			if ($date_from instanceof \DateTime) {
+				$date_from->setTime(0, 0, 0);
 
-			$this->data_source->where('DATE(%n) >= ?', $filter->getColumn(), $date_from);
+				$this->data_source->where('DATE(%n) >= ?', $filter->getColumn(), $date_from);
+			}
 		}
 
 		if ($value_to) {
 			$date_to = \DateTime::createFromFormat($filter->getPhpFormat(), $value_to);
-			$date_to->setTime(23, 59, 59);
+			if ($date_to instanceof \DateTime) {
+				$date_to->setTime(23, 59, 59);
 
-			$this->data_source->where('DATE(%n) <= ?', $filter->getColumn(), $date_to);
+				$this->data_source->where('DATE(%n) <= ?', $filter->getColumn(), $date_to);
+			}
 		}
 	}
 

--- a/src/DataSource/DibiFluentMssqlDataSource.php
+++ b/src/DataSource/DibiFluentMssqlDataSource.php
@@ -83,10 +83,11 @@ class DibiFluentMssqlDataSource extends DibiFluentDataSource
 		$conditions = $filter->getCondition();
 
 		$date = \DateTime::createFromFormat($filter->getPhpFormat(), $conditions[$filter->getColumn()]);
+		if ($date instanceof \DateTime) {
+			$ymd = $date->format('Ymd');
 
-		$ymd = $date->format('Ymd');
-
-		$this->data_source->where('CONVERT(varchar(10), %n, 112) = ?', $filter->getColumn(), $ymd);
+			$this->data_source->where('CONVERT(varchar(10), %n, 112) = ?', $filter->getColumn(), $ymd);
+		}
 	}
 
 

--- a/src/DataSource/DoctrineDataSource.php
+++ b/src/DataSource/DoctrineDataSource.php
@@ -150,13 +150,15 @@ class DoctrineDataSource extends FilterableDataSource implements IDataSource
 
 		foreach ($filter->getCondition() as $column => $value) {
 			$date = \DateTime::createFromFormat($filter->getPhpFormat(), $value);
-			$c = $this->checkAliases($column);
+			if ($date instanceof \DateTime) {
+				$c = $this->checkAliases($column);
 
-			$this->data_source
-				->andWhere("$c >= ?$p1")
-				->andWhere("$c <= ?$p2")
-				->setParameter($p1, $date->format('Y-m-d 00:00:00'))
-				->setParameter($p2, $date->format('Y-m-d 23:59:59'));
+				$this->data_source
+					->andWhere("$c >= ?$p1")
+					->andWhere("$c <= ?$p2")
+					->setParameter($p1, $date->format('Y-m-d 00:00:00'))
+					->setParameter($p2, $date->format('Y-m-d 23:59:59'));
+			}
 		}
 	}
 
@@ -175,20 +177,25 @@ class DoctrineDataSource extends FilterableDataSource implements IDataSource
 
 		if ($value_from) {
 			$date_from = \DateTime::createFromFormat($filter->getPhpFormat(), $value_from);
-			$date_from->setTime(0, 0, 0);
+			if ($date_from instanceof \DateTime) {
+				$date_from->setTime(0, 0, 0);
 
-			$p = $this->getPlaceholder();
+				$p = $this->getPlaceholder();
 
-			$this->data_source->andWhere("$c >= ?$p")->setParameter($p, $date_from->format('Y-m-d H:i:s'));
+				$this->data_source->andWhere("$c >= ?$p")->setParameter($p, $date_from->format('Y-m-d H:i:s'));
+			}
+
 		}
 
 		if ($value_to) {
 			$date_to = \DateTime::createFromFormat($filter->getPhpFormat(), $value_to);
-			$date_to->setTime(23, 59, 59);
+			if ($date_to instanceof \DateTime) {
+				$date_to->setTime(23, 59, 59);
 
-			$p = $this->getPlaceholder();
+				$p = $this->getPlaceholder();
 
-			$this->data_source->andWhere("$c <= ?$p")->setParameter($p, $date_to->format('Y-m-d H:i:s'));
+				$this->data_source->andWhere("$c <= ?$p")->setParameter($p, $date_to->format('Y-m-d H:i:s'));
+			}
 		}
 	}
 

--- a/src/DataSource/NetteDatabaseTableDataSource.php
+++ b/src/DataSource/NetteDatabaseTableDataSource.php
@@ -98,8 +98,10 @@ class NetteDatabaseTableDataSource extends FilterableDataSource implements IData
 		$conditions = $filter->getCondition();
 
 		$date = \DateTime::createFromFormat($filter->getPhpFormat(), $conditions[$filter->getColumn()]);
+		if ($date instanceof \DateTime) {
 
-		$this->data_source->where("DATE({$filter->getColumn()}) = ?", $date->format('Y-m-d'));
+			$this->data_source->where("DATE({$filter->getColumn()}) = ?", $date->format('Y-m-d'));
+		}
 	}
 
 
@@ -117,16 +119,20 @@ class NetteDatabaseTableDataSource extends FilterableDataSource implements IData
 
 		if ($value_from) {
 			$date_from = \DateTime::createFromFormat($filter->getPhpFormat(), $value_from);
-			$date_from->setTime(0, 0, 0);
+			if ($date_from instanceof \DateTime) {
+				$date_from->setTime(0, 0, 0);
 
-			$this->data_source->where("DATE({$filter->getColumn()}) >= ?", $date_from->format('Y-m-d'));
+				$this->data_source->where("DATE({$filter->getColumn()}) >= ?", $date_from->format('Y-m-d'));
+			}
 		}
 
 		if ($value_to) {
 			$date_to = \DateTime::createFromFormat($filter->getPhpFormat(), $value_to);
-			$date_to->setTime(23, 59, 59);
+			if ($date_to instanceof \DateTime) {
+				$date_to->setTime(23, 59, 59);
 
-			$this->data_source->where("DATE({$filter->getColumn()}) <= ?", $date_to->format('Y-m-d'));
+				$this->data_source->where("DATE({$filter->getColumn()}) <= ?", $date_to->format('Y-m-d'));
+			}
 		}
 	}
 

--- a/src/DataSource/NetteDatabaseTableMssqlDataSource.php
+++ b/src/DataSource/NetteDatabaseTableMssqlDataSource.php
@@ -24,11 +24,13 @@ class NetteDatabaseTableMssqlDataSource extends NetteDatabaseTableDataSource imp
 		$conditions = $filter->getCondition();
 
 		$date = \DateTime::createFromFormat($filter->getPhpFormat(), $conditions[$filter->getColumn()]);
+		if ($date instanceof \DateTime) {
+            $this->data_source->where(
+                "CONVERT(varchar(10), {$filter->getColumn()}, 112) = ?",
+                $date->format('Ymd')
+            );
+		}
 
-		$this->data_source->where(
-			"CONVERT(varchar(10), {$filter->getColumn()}, 112) = ?",
-			$date->format('Ymd')
-		);
 	}
 
 
@@ -46,22 +48,26 @@ class NetteDatabaseTableMssqlDataSource extends NetteDatabaseTableDataSource imp
 
 		if ($value_from) {
 			$date_from = \DateTime::createFromFormat($filter->getPhpFormat(), $value_from);
-			$date_from->setTime(0, 0, 0);
+			if ($date_from instanceof \DateTime) {
+				$date_from->setTime(0, 0, 0);
 
-			$this->data_source->where(
-				"CONVERT(varchar(10), {$filter->getColumn()}, 112) >= ?",
-				$date_from->format('Ymd')
-			);
+                $this->data_source->where(
+                    "CONVERT(varchar(10), {$filter->getColumn()}, 112) >= ?",
+                    $date_from->format('Ymd')
+                );
+			}
 		}
 
 		if ($value_to) {
 			$date_to = \DateTime::createFromFormat($filter->getPhpFormat(), $value_to);
-			$date_to->setTime(23, 59, 59);
+			if ($date_to instanceof \DateTime) {
+				$date_to->setTime(23, 59, 59);
 
-			$this->data_source->where(
-				"CONVERT(varchar(10), {$filter->getColumn()}, 112) <= ?",
-				$date_to->format('Ymd')
-			);
+                $this->data_source->where(
+                    "CONVERT(varchar(10), {$filter->getColumn()}, 112) <= ?",
+                    $date_to->format('Ymd')
+                );
+			}
 		}
 	}
 


### PR DESCRIPTION
I've added check in datasources when using  \DateTime::createFromFormat($format, $time)
in case of $time doesn't correspond the $format the function returns FALSE

The check should avoid getting 500

and some minor changes
