### PR TITLE
Update InlineEdit.php

### DIFF
--- a/src/InlineEdit/InlineEdit.php
+++ b/src/InlineEdit/InlineEdit.php
@@ -210,7 +210,7 @@ class InlineEdit extends Nette\Object
 					break;
 				
 				default:
-					if (empty($control->getControl()->getAttribute('class'))) {
+					if (empty($control->getControl()->getClass())) {
 						$control->setAttribute('class', 'form-control input-sm');
 					}
 


### PR DESCRIPTION
Špatný getter, nevracel class. 

U Inline Add se správně zobrazí bootstrap-select css třída: selectpicker, css je načteno s datagridem.
ale u Inline Edit (XHR) se neaplikuje css, 

viz. issue https://github.com/ublaboo/datagrid/issues/299