### PR TITLE
DoctrineDataSource: Added data loaded callback

### DIFF
--- a/src/DataGrid.php
+++ b/src/DataGrid.php
@@ -540,6 +540,19 @@ class DataGrid extends Nette\Application\UI\Control
 	}
 
 
+	/**
+	 * @return DataSource\IDataSource|NULL
+	 */
+	public function getDataSource()
+	{
+		if (!$this->dataModel) {
+			return NULL;
+		}
+
+		return $this->dataModel->getDataSource();
+	}
+
+
 	/********************************************************************************
 	 *                                  TEMPLATING                                  *
 	 ********************************************************************************/

--- a/src/DataSource/FilterableDataSource.php
+++ b/src/DataSource/FilterableDataSource.php
@@ -13,7 +13,7 @@ use Nette\Utils\Callback;
 use Nette\Utils\Strings;
 use Ublaboo\DataGrid\Filter;
 
-abstract class FilterableDataSource
+abstract class FilterableDataSource extends \Nette\Object
 {
 
 	/**


### PR DESCRIPTION
We should talk about the name of the method/property for this callback as I am not satisfied with this name.

I've tested this on one of my projects and it already cut 14 queries to just 4 thanks to the [post fetching](https://github.com/Kdyby/Doctrine/blob/master/docs/en/optimizing-query-objects.md) the entities for associations in separate query.

This is how I've used it:
```php
$grid->getDataSource()->setLoadedCallback(function ($orders) {
	$this->orderRepository->createQueryBuilder('o', 'o.id')
		->select('partial o.{id}, v, c')
		->leftJoin('o.vehicles', 'v')
		->leftJoin('o.comments', 'c')
		->where('o IN (:orders)')
		->getQuery()
		->setParameter('orders', $orders)
		->getResult();
});
```

//cc @JakubKontra 