### PR TITLE
Add summary callback to set if you want to add row into sum.

### DIFF
--- a/src/ColumnsSummary.php
+++ b/src/ColumnsSummary.php
@@ -57,18 +57,18 @@ class ColumnsSummary
 	}
 
 	/**
-	 * Check if can add row sum into sums.. check for every summary column
-	 * @param Row    $row
-	 * @param string $column
+	 * Get value from column.. (with callback or classic getValue from row)
+	 * @param Row    	    $row
+	 * @param Column\Column $column
 	 * @return bool
 	 */
-	private function canColumnAdd(Row $row, $column)
+	private function getValue(Row $row, $column)
 	{
 		if (empty($this->rowCallback)) {
-			return TRUE;
+			return $row->getValue($column->getColumn());
 		}
 
-		return Callback::invoke($this->rowCallback, $row->getItem(), $column);
+		return Callback::invoke($this->rowCallback, $row->getItem(), $column->getColumn());
 	}
 
 	/**
@@ -79,10 +79,8 @@ class ColumnsSummary
 		foreach ($this->summary as $key => $sum) {
 			$column = $this->datagrid->getColumn($key);
 
-			if ($this->canColumnAdd($row, $column->getColumn())) {
-				$value = $row->getValue($column->getColumn());
-				$this->summary[$key] += $value;
-			}
+			$value = $this->getValue($row, $column);
+			$this->summary[$key] += $value;
 		}
 	}
 

--- a/src/DataGrid.php
+++ b/src/DataGrid.php
@@ -2793,12 +2793,19 @@ class DataGrid extends Nette\Application\UI\Control
 
 	/**
 	 * Set columns to be summarized in the end.
-	 * @param  array  $columns
-	 * @return ColumnsSummary
+	 * @param array    $columns
+	 * @param callable $rowCallback
+	 * @return \Ublaboo\DataGrid\ColumnsSummary
 	 */
-	public function setColumnsSummary(array $columns)
+	public function setColumnsSummary(array $columns, $rowCallback = NULL)
 	{
-		$this->columnsSummary = new ColumnsSummary($this, $columns);
+		if (!empty($rowCallback)) {
+			if (!is_callable($rowCallback)) {
+				throw new \InvalidArgumentException('Row summary callback must be callable');
+			}
+		}
+
+		$this->columnsSummary = new ColumnsSummary($this, $columns, $rowCallback);
 
 		return $this->columnsSummary;
 	}


### PR DESCRIPTION
Little feature for column summary. If you want to exclude some rows from summary. 

Now you can do it with this code.

```
$grid->setColumnsSummary(['amount', 'id'], function (CashItem $item, $columnName) {
		if ($columnName != "amount") {
			return TRUE;
		}
		return !$item->getDeleted();
	});
```