### PR TITLE
Set filters in seperate rows

### DIFF
--- a/src/templates/datagrid.latte
+++ b/src/templates/datagrid.latte
@@ -122,7 +122,9 @@
 							</span>
 						</th>
 					</tr>
-					<tr n:block="header">
+					</thead>
+				<thead n:block="header">
+					<tr n:block="header-column-row">
 						<th n:if="$hasGroupActionOnRows" rowspan="2" class="col-checkbox">
 							<input n:class="$control->useHappyComponents() ? 'happy gray-border' , primary" name="{$control->getName()|lower}-toggle-all" type="checkbox" data-check="{$control->getName()}" data-check-all="{$control->getName()}">
 						</th>

--- a/src/templates/datagrid.latte
+++ b/src/templates/datagrid.latte
@@ -168,32 +168,39 @@
 											</ul>
 										</div>
 									</span>
-								{/ifset}
-
-								{if !$control->hasOuterFilterRendering() && isset($filters[$key])}
-									<hr>
-									{var $i = $filter['filter'][$key]}
+                                {/ifset}
+                            {$th->endTag()|noescape}
+						{/foreach}
+						<th n:if="$actions || $control->isSortable() || $items_detail || $inlineEdit || $inlineAdd" class="col-action text-center">
+							{_'ublaboo_datagrid.action'}
+						</th>
+					</tr>
+					<tr n:block="header-filters" n:if="!$control->hasOuterFilterRendering()">
+						{foreach $columns as $key => $column}
+							{var $th = $column->getElementPrototype('th', $key)}
+							{$th->startTag()|noescape}
+							{var $col_header = 'col-filter-' . $key . '-header'}
+							{if !$control->hasOuterFilterRendering() && isset($filters[$key])}
+								{var $i = $filter['filter'][$key]}
 
 									{var $filter_block = 'filter-' . $filters[$key]->getKey()}
 									{var $filter_type_block = 'filtertype-' . $filters[$key]->getType()}
 
-									{ifset #$filter_block}
-										{include #$filter_block, filter => $filters[$key], input => $i, outer => FALSE}
+								{ifset #$filter_block}
+									{include #$filter_block, filter => $filters[$key], input => $i, outer => FALSE}
+								{else}
+									{ifset #$filter_type_block}
+										{include #$filter_type_block, filter => $filters[$key], input => $i, outer => FALSE}
 									{else}
-										{ifset #$filter_type_block}
-											{include #$filter_type_block, filter => $filters[$key], input => $i, outer => FALSE}
-										{else}
-											{include $filters[$key]->getTemplate(), filter => $filters[$key], input => $i, outer => FALSE}
-										{/ifset}
+										{include $filters[$key]->getTemplate(), filter => $filters[$key], input => $i, outer => FALSE}
 									{/ifset}
+								{/ifset}
 
-								{/if}
+							{/if}
 							{$th->endTag()|noescape}
 						{/foreach}
 						<th n:if="$actions || $control->isSortable() || $items_detail || $inlineEdit || $inlineAdd" class="col-action text-center">
-							{_'ublaboo_datagrid.action'}
 							{if !$control->hasAutoSubmit() && !$control->hasOuterFilterRendering()}
-								<hr>
 								{input $filter['filter']['submit']}
 							{/if}
 						</th>


### PR DESCRIPTION
Input fielters should have their own row IMHO.
before: 
![before](https://cloud.githubusercontent.com/assets/9303856/17643355/1d8a5a92-6168-11e6-93df-1c8a73b5b51f.png)

after: 
![after](https://cloud.githubusercontent.com/assets/9303856/17643356/22ad3dd2-6168-11e6-98fc-9185d2d19699.png)


Also this is first step for successfully resolving issue https://github.com/ublaboo/datagrid/issues/270
but it's standalone feature as well so I'm creating PR only for it.