### PR TITLE
fix DataGrid::removeColumn()

### DIFF
--- a/src/DataGrid.php
+++ b/src/DataGrid.php
@@ -927,6 +927,7 @@ class DataGrid extends Nette\Application\UI\Control
 	 */
 	public function removeColumn($key)
 	{
+		unset($this->columns_visibility[$key]);
 		unset($this->columns[$key]);
 	}
 

--- a/tests/Cases/ColumnTextTest.phpt
+++ b/tests/Cases/ColumnTextTest.phpt
@@ -57,6 +57,14 @@ final class ColumnStatusTest extends TestCase
 		Assert::same(2, $current_option->getValue());
 	}
 
+
+	public function testRemoveColumn()
+	{
+		$grid = $this->grid;
+		$grid->addColumnText('test', 'Test');
+		$grid->removeColumn('test');
+		$grid->getColumnsVisibility();
+	}
 }
 
 


### PR DESCRIPTION
After call method DataGrid::removeColumn('test') -> method DataGrid::getColumnsVisibility() throw E_NOTICE: Undefined index.
This PR fix this problem.