### PR TITLE
fix Column::setSortableCallback() (in DataGrid::createSorting())

### DIFF
--- a/src/DataGrid.php
+++ b/src/DataGrid.php
@@ -720,6 +720,11 @@ class DataGrid extends Nette\Application\UI\Control
 			$sort = [$column->getSortingColumn() => $order];
 		}
 
+		// required for first request
+		if (isset($column) && $sort_callback === NULL) {
+			$sort_callback = $column->getSortableCallback();
+		}
+
 		return new Sorting($sort, $sort_callback);
 	}
 


### PR DESCRIPTION
use-case:

        $grid->addColumnText('translationEn', 'Translation', 'translation')
            ->setSortable()
            ->setSortableCallback(function (QueryBuilder $qb, $sort) {
                $qb->leftJoin('i.translations', 'tr_sort_cs', Join::WITH, 'tr_sort_cs.language = 1')
                    ->orderBy('tr_sort_cs.text', $sort['translation']);
            })

$sort_callback was nullable for init request and throw Doctrine\ORM\Query\QueryException

This PR fixed this issue.