### PR TITLE
Add mysqli extension to tests/php.ini

### DIFF
--- a/tests/php.ini
+++ b/tests/php.ini
@@ -1,2 +1,3 @@
 extension_dir = "./ext"
 extension=php_pdo_sqlite.dll
+extension=php_mysqli.dll


### PR DESCRIPTION
Now it's possible to run tests on your dev machine with nette tester,
you just have to create mysql db "datagridTest" and mysql user travis with no password and give travis user permissions to datagridTests.
Although I believe better aproach wouuld be through mock objects....