### PR TITLE
Fix for fetch-joined DoctrineDataSource

### DIFF
--- a/src/DataSource/DoctrineDataSource.php
+++ b/src/DataSource/DoctrineDataSource.php
@@ -109,10 +109,13 @@ class DoctrineDataSource extends FilterableDataSource implements IDataSource
 	 */
 	public function getData()
 	{
-		$result = $this->getQuery()->getResult();
-		$this->onDataLoaded($result);
+		$iterator = (new Paginator($this->getQuery()))->getIterator();
 
-		return $result;
+		$data = iterator_to_array($iterator);
+
+		$this->onDataLoaded($data);
+
+		return $data;
 	}
 
 


### PR DESCRIPTION
Method getCount correctly uses doctrine's Paginator, but getData returns result directly. It's causing wrong pagination in grid if you provide QueryBuilder with joins - shows less rows than it should be.

This commit change getData method to return result via doctrine's Paginator.

@see http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/tutorials/pagination.html

Problem was mentioned in #100 too.