### PR TITLE
Escape column identifier in DibiFluentDataSource

### DIFF
--- a/src/DataSource/DibiFluentDataSource.php
+++ b/src/DataSource/DibiFluentDataSource.php
@@ -158,6 +158,7 @@ class DibiFluentDataSource extends FilterableDataSource implements IDataSource
 		$or = [];
 
 		foreach ($condition as $column => $value) {
+			$column = $this->data_source->getConnection()->getDriver()->escape($column, \dibi::IDENTIFIER);
 			if($filter->isExactSearch()){
 				$this->data_source->where("$column = %s", $value);
 				continue;


### PR DESCRIPTION
When using SQL keyword as column name, in my case 'key', you'll get SQL syntax error when filtering with that column. This fixes it.