### PR TITLE
Add row condition for item detail

### DIFF
--- a/src/Column/ItemDetail.php
+++ b/src/Column/ItemDetail.php
@@ -60,7 +60,7 @@ class ItemDetail
 	/**
 	 * @var callable
 	 */
-	protected $render_condition;
+	protected $render_condition_callback;
 
 
 	/**
@@ -243,7 +243,7 @@ class ItemDetail
 	 */
 	public function setRenderCondition(callable $condition)
 	{
-		$this->render_condition = $condition;
+		$this->render_condition_callback = $condition;
 
 		return $this;
 	}
@@ -254,7 +254,7 @@ class ItemDetail
 	 */
 	public function shouldBeRendered(Row $row)
 	{
-		$condition = $this->render_condition;
+		$condition = $this->render_condition_callback;
 
 		return $condition ? $condition($row->getItem()) : TRUE;
 	}

--- a/src/Column/ItemDetail.php
+++ b/src/Column/ItemDetail.php
@@ -14,6 +14,7 @@ use Ublaboo\DataGrid\DataGrid;
 use Ublaboo;
 use Ublaboo\DataGrid\Traits;
 use Ublaboo\DataGrid\Exception\DataGridItemDetailException;
+use Ublaboo\DataGrid\Row;
 
 class ItemDetail
 {
@@ -55,6 +56,11 @@ class ItemDetail
 	 * @var array
 	 */
 	protected $template_parameters = [];
+	
+	/**
+	 * @var callable
+	 */
+	protected $render_condition;
 
 
 	/**
@@ -229,6 +235,28 @@ class ItemDetail
 	public function getTemplateVariables()
 	{
 		return $this->template_parameters;
+	}
+
+	/**
+	 * @param callable $condition
+	 * @return static
+	 */
+	public function setRenderCondition(callable $condition)
+	{
+		$this->render_condition = $condition;
+
+		return $this;
+	}
+
+	/**
+	 * @param Row $row
+	 * @return bool
+	 */
+	public function shouldBeRendered(Row $row)
+	{
+		$condition = $this->render_condition;
+
+		return $condition ? $condition($row->getItem()) : TRUE;
 	}
 
 }

--- a/src/templates/datagrid.latte
+++ b/src/templates/datagrid.latte
@@ -283,7 +283,7 @@
 											{if $inlineEdit && $row->hasInlineEdit()}
 												{$inlineEdit->renderButton($row)|noescape}
 											{/if}
-											{if $items_detail}
+											{if $items_detail && $items_detail->shouldBeRendered($row)}
 												{$items_detail->renderButton($row)|noescape}
 											{/if}
 										</td>
@@ -294,7 +294,7 @@
 							{**
 							 * Item detail
 							 *}
-							{if $items_detail}
+							{if $items_detail && $items_detail->shouldBeRendered($row)}
 								<tr class="row-item-detail item-detail-{$row->getId()}" n:snippet="item-{$row->getId()}-detail">
 									{if isset($toggle_detail) && $toggle_detail == $row->getId()}
 										{var $item_detail_params = ['item' => $item, '_form' => $filter] + $items_detail->getTemplateVariables()}


### PR DESCRIPTION
Hi,

this PR allows to set callback as condition to render or not to render item detail for a specific row.

It is called directly on ItemDetail, are you ok with this aproach? Or should I rework it in a way like [existing row conditions](https://github.com/ublaboo/datagrid/blob/v4.4.22/src/DataGrid.php#L2701) - new methods DataGrid::allowItemDetail(callable) and Row::hasItemDetail() ?

I like this way more, but I can be wrong.