### PR TITLE
Missing semicolon in Datagrid.php

### DIFF
--- a/src/DataGrid.php
+++ b/src/DataGrid.php
@@ -2719,7 +2719,7 @@ class DataGrid extends Nette\Application\UI\Control
 	public function deleteSesssionData($key)
 	{
 		@trigger_error('deleteSesssionData is deprecated, use deleteSessionData instead', E_USER_DEPRECATED);
-		return $this->deleteSessionData($key)
+		return $this->deleteSessionData($key);
 	}
 
 


### PR DESCRIPTION
@juniwalk I believe you hurried up and made this mistake on master branch.
Would be great if you merge this ASAP since many users also have dev-master in their composer and this could crash production...