### PR TITLE
Basic support for related column names

### DIFF
--- a/src/Row.php
+++ b/src/Row.php
@@ -92,6 +92,12 @@ class Row extends Nette\Object
 			return $this->item->{$this->formatDibiRowKey($key)};
 
 		} else if ($this->item instanceof ActiveRow) {
+			if (preg_match("/^:([a-zA-Z0-9_$]*)\.([a-zA-Z0-9_$]*)$/", $key, $matches)) {
+				$relatedTable = $matches[1];
+				$relatedColumn = $matches[2];
+
+				return $this->item->related($relatedTable)->fetch()->{$relatedColumn};
+			}
 			return $this->item->{$key};
 
 		} else if ($this->item instanceof Nette\Database\Row) {


### PR DESCRIPTION
Added basic support for syntax $grid->addColumnType('name', 'Title', ':related_table.column') when using Nette Database