### PR TITLE
Don't change collation when searching in DibiFluent

### DIFF
--- a/src/DataSource/DibiFluentDataSource.php
+++ b/src/DataSource/DibiFluentDataSource.php
@@ -179,13 +179,8 @@ class DibiFluentDataSource extends FilterableDataSource implements IDataSource
 
 			foreach ($words as $word) {
 				$escaped = $this->data_source->getConnection()->getDriver()->escapeLike($word, 0);
+				$or[] = "$column LIKE $escaped";
 
-				if (preg_match("/[\x80-\xFF]/", $escaped)) {
-					$or[] = "$column LIKE $escaped COLLATE utf8_bin";
-				} else {
-					$escaped = Strings::toAscii($escaped);
-					$or[] = "$column LIKE $escaped COLLATE utf8_general_ci";
-				}
 			}
 		}
 


### PR DESCRIPTION
For me search on this way works much better. I can live with forcing utf8_general_ci
But I don't see a point switching to utf8_bin when some UTF8 character is in search?
Any explanation, or anything else? It's wierd now that search become case sensitive immidiatelly when utf-8 character appear, not to mention completelly different behavior... 