### PR TITLE
Allows to disable translator

### DIFF
--- a/src/DataGrid.php
+++ b/src/DataGrid.php
@@ -2642,7 +2642,7 @@ class DataGrid extends Nette\Application\UI\Control
 	 * @param Nette\Localization\ITranslator $translator
 	 * @return static
 	 */
-	public function setTranslator(Nette\Localization\ITranslator $translator)
+	public function setTranslator(Nette\Localization\ITranslator $translator = NULL)
 	{
 		$this->translator = $translator;
 


### PR DESCRIPTION
Previously it was failing due to `Argument 1 passed to Ublaboo\DataGrid\DataGrid::setTranslator() must implement interface Nette\Localization\ITranslator, null given`