### PR TITLE
Fix calling referred column

### DIFF
--- a/src/Row.php
+++ b/src/Row.php
@@ -98,6 +98,13 @@ class Row extends Nette\Object
 
 				return $this->item->related($relatedTable)->fetch()->{$relatedColumn};
 			}
+
+			if (preg_match("/^([a-zA-Z0-9_$]*)\.([a-zA-Z0-9_$]*)$/", $key, $matches)) {
+				$referredTable = $matches[1];
+				$referredColumn = $matches[2];
+
+				return $this->item->ref($referredTable)->{$referredColumn};
+			}
 			return $this->item->{$key};
 
 		} else if ($this->item instanceof Nette\Database\Row) {


### PR DESCRIPTION
There was some bug when I call this:

`$grid->addColumnText('sport', 'Sport', 'sport.name');`

Then a Nette application throws Nette\MemberAccessException with message Cannot read an undeclared column 'sport.name'.

Nette: 2.4
PHP: 7.0.8-0ubuntu0.16.04.3