### PR TITLE
Backward compatibility for PHP 5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
 		"nette/forms"       : "^2.3|^2.4",
 		"ublaboo/responses" : "~1.0.0",
 		"ublaboo/controls"  : "~1.0.1",
-		"symfony/property-access": "2.8.15"
+		"symfony/property-access": ">=2.8.15"
 	},
 	"require-dev": {
 		"nette/tester"     : "^1.6.1",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
 		"nette/forms"       : "^2.3|^2.4",
 		"ublaboo/responses" : "~1.0.0",
 		"ublaboo/controls"  : "~1.0.1",
-		"symfony/property-access": "~3.0"
+		"symfony/property-access": "2.8.15"
 	},
 	"require-dev": {
 		"nette/tester"     : "^1.6.1",

--- a/src/DataGrid.php
+++ b/src/DataGrid.php
@@ -3290,7 +3290,7 @@ class DataGrid extends Nette\Application\UI\Control
 	 */
 	public function getSortableParentPath()
 	{
-		return $this->getParent()->lookupPath(Nette\Application\UI\Control::class, FALSE);
+		return $this->getParent()->lookupPath('Nette\Application\UI\Control', FALSE);
 	}
 
 


### PR DESCRIPTION
Hello, these lines add backward compatibility for PHP 5.4.x. 
It can be useful for someone who is not able to have higher version of PHP on production server.