### PR TITLE
Fixed DoctrineDataSource filtering

### DIFF
--- a/src/DataSource/DoctrineDataSource.php
+++ b/src/DataSource/DoctrineDataSource.php
@@ -11,6 +11,7 @@ namespace Ublaboo\DataGrid\DataSource;
 
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\ORM\Tools\Pagination\Paginator;
+use Nette\Utils\Callback;
 use Nette\Utils\Strings;
 use Ublaboo\DataGrid\Filter;
 use Ublaboo\DataGrid\Utils\DateTimeHelper;
@@ -117,6 +118,48 @@ class DoctrineDataSource extends FilterableDataSource implements IDataSource
 		$this->onDataLoaded($data);
 
 		return $data;
+	}
+
+
+	/**
+	 * Filter data
+	 * @param array $filters
+	 * @return static
+	 */
+	public function filter(array $filters)
+	{
+		$withConditionCallback = [];
+
+		foreach ($filters as $filter) {
+			if ($filter->isValueSet()) {
+				if ($filter->hasConditionCallback()) {
+					$withConditionCallback[] = $filter;
+				} else {
+					if ($filter instanceof Filter\FilterText) {
+						$this->applyFilterText($filter);
+					} else if ($filter instanceof Filter\FilterMultiSelect) {
+						$this->applyFilterMultiSelect($filter);
+					} else if ($filter instanceof Filter\FilterSelect) {
+						$this->applyFilterSelect($filter);
+					} else if ($filter instanceof Filter\FilterDate) {
+						$this->applyFilterDate($filter);
+					} else if ($filter instanceof Filter\FilterDateRange) {
+						$this->applyFilterDateRange($filter);
+					} else if ($filter instanceof Filter\FilterRange) {
+						$this->applyFilterRange($filter);
+					}
+				}
+			}
+		}
+
+		foreach ($withConditionCallback as $filter) {
+			Callback::invokeArgs(
+				$filter->getConditionCallback(),
+				[$this->data_source, $filter->getValue()]
+			);
+		}
+
+		return $this;
 	}
 
 


### PR DESCRIPTION
When you have filter with native and custom condition, native condition uses postional parameter in `QueryBuilder` and custom condition must use named parameter. For example:

```php
public function createConditionYear(QueryBuilder $queryBuilder, $value)
{
	if ($value) {
		$queryBuilder->andWhere('actuarial.createYear = :year')
			->setParameter('year', $value);
	}
}
```

With another native condition, result in DQL would be something like this:

```sql
SELECT actuarial
FROM Actuarial
WHERE actuarial.createYear = :year AND actuarial.type = ?0
```

If native condition is evaluated after named condition, doctrine rewrites first value, in this case year and second value is never set (error is thrown). When named conditions are evaluated after positional, everything works ok.

Better approach could be generating named aliases instead of positional arguments in native conditions.