### PR TITLE
composer: remove redundant versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,9 @@
 		}
 	},
 	"require": {
-		"nette/application" : "^2.3|^2.4",
+		"nette/application" : "^2.3",
 		"nette/utils"       : ">=2.3.10",
-		"nette/forms"       : "^2.3|^2.4",
+		"nette/forms"       : "^2.3",
 		"ublaboo/responses" : "~1.0.0",
 		"ublaboo/controls"  : "~1.0.1",
 		"symfony/property-access": "~3.0"
@@ -39,7 +39,7 @@
 		"tharos/leanmapper": "~2.2.0",
 		"nextras/orm"      : "~2.0",
 		"doctrine/orm"	   : "~2.5",
-		"nette/database"   : "^2.3|^2.4",
+		"nette/database"   : "^2.3",
 		"dibi/dibi"   : "^3.0"
 	}
 }


### PR DESCRIPTION
`^2.3` equals to `>=2.3 | < 3.0`

So `^2.3 | ^2.4 | ^2.4+n` doesn't make sense.

See [caret in Composer docs](https://getcomposer.org/doc/articles/versions.md#caret)