### PR TITLE
Fixed reload table after filtering

### DIFF
--- a/src/DataGrid.php
+++ b/src/DataGrid.php
@@ -1735,7 +1735,7 @@ class DataGrid extends Nette\Application\UI\Control
 			}
 		}
 
-		$this->reload();
+		$this->reload(['table']);
 	}
 
 


### PR DESCRIPTION
When is used group actions and conditions to allow group action on rows, on one page may not be visible checboxes and after filtering can be. After it, header inputs not be displayed.