### PR TITLE
Fix getSortableParentPath() - return full path when inside components

### DIFF
--- a/src/DataGrid.php
+++ b/src/DataGrid.php
@@ -3311,11 +3311,11 @@ class DataGrid extends Nette\Application\UI\Control
 
 
 	/**
-	 * @return strign
+	 * @return string
 	 */
 	public function getSortableParentPath()
 	{
-		return $this->getParent()->lookupPath(Nette\Application\UI\Control::class, FALSE);
+		return $this->getParent()->lookupPath(Nette\Application\IPresenter::class, FALSE);
 	}
 
 


### PR DESCRIPTION
_Sorry about opening new PR, I messed something up with the branch before._

When DataGrid is nested inside components, this function only returns last component name and the parameters for sorting handle are not correctly passed (bad prefix).

For example if I have component FooDataGrid inside component Bar, it only returns fooDataGrid instead of bar-fooDataGrid.

With this fix, getSortableParentPath() is returning full unique path to our DataGrid component. It is working for DataGrids inside components and also for DataGrids created directly in presenters too.