### PR TITLE
Add selected rows count

### DIFF
--- a/assets/dist/datagrid.js
+++ b/assets/dist/datagrid.js
@@ -71,6 +71,12 @@ $(document).on('keydown', 'input[data-datagrid-manualsubmit]', function(e) {
   }
 });
 
+$('input[data-check-all-grid]').on('change', function(){
+    var selected = $('input[data-check-all-grid]:checked').length;
+    var total = $('input[data-check-all-grid]').length;
+    $('.datagrid-selected-rows-count').text( + '/' + total);
+});
+
 datagridShiftGroupSelection = function() {
   var last_checkbox;
   last_checkbox = null;

--- a/src/templates/datagrid.latte
+++ b/src/templates/datagrid.latte
@@ -85,6 +85,7 @@
 											{input $form_control, style => 'display:none'}
 										{/if}
 									{/foreach}
+									<span class="datagrid-selected-rows-count"></span>
 								{/block}
 							{/if}
 


### PR DESCRIPTION
Add selected rows count after group actions controls. I don't work with coffee script, only js and ts so someone should probably do something about that and maybe there should be some text like (rows selected), although I like this form as well. In any way I believe this info should be somehow displayed near group action inputs