### PR TITLE
DoctrineDataSource: use Paginator only when needed

### DIFF
--- a/src/DataSource/DoctrineDataSource.php
+++ b/src/DataSource/DoctrineDataSource.php
@@ -89,6 +89,15 @@ class DoctrineDataSource extends FilterableDataSource implements IDataSource
 	}
 
 
+	/**
+	 * @return bool
+	 */
+	private function usePaginator()
+	{
+		return $this->data_source->getDQLPart('join') || $this->data_source->getDQLPart('groupBy');
+	}
+
+
 	/********************************************************************************
 	 *                          IDataSource implementation                          *
 	 ********************************************************************************/
@@ -100,7 +109,13 @@ class DoctrineDataSource extends FilterableDataSource implements IDataSource
 	 */
 	public function getCount()
 	{
-		return (new Paginator($this->getQuery()))->count();
+		if ($this->usePaginator()) {
+			return (new Paginator($this->getQuery()))->count();
+		}
+		$data_source = clone $this->data_source;
+		$data_source->select(sprintf('COUNT(%s)', $this->checkAliases($this->primary_key)));
+
+		return (int) $data_source->getQuery()->getSingleScalarResult();
 	}
 
 
@@ -110,9 +125,13 @@ class DoctrineDataSource extends FilterableDataSource implements IDataSource
 	 */
 	public function getData()
 	{
-		$iterator = (new Paginator($this->getQuery()))->getIterator();
+		if ($this->usePaginator()) {
+			$iterator = (new Paginator($this->getQuery()))->getIterator();
 
-		$data = iterator_to_array($iterator);
+			$data = iterator_to_array($iterator);
+		} else {
+			$data = $this->getQuery()->getResult();
+		}
 
 		$this->onDataLoaded($data);
 


### PR DESCRIPTION
Paginator is used only if join/groupBy is used in query. For simple data without join it is unnecessarily slow AF.