### PR TITLE
Support nextras traversing in basic sortable usage

### DIFF
--- a/src/DataSource/NextrasDataSource.php
+++ b/src/DataSource/NextrasDataSource.php
@@ -279,7 +279,7 @@ class NextrasDataSource extends FilterableDataSource implements IDataSource
 
 		if (!empty($sort)) {
 			foreach ($sort as $column => $order) {
-				$this->data_source = $this->data_source->orderBy($column, $order);
+				$this->data_source = $this->data_source->orderBy($this->prepareColumn($column), $order);
 			}
 		} else {
 			/**


### PR DESCRIPTION
Když používám nextras a ublaboo dohromady, tak musím při označování traverzovaných sloupců jako sortable uvést nextras cestu. Všiml jsem si, že tam je na to hezký helper, tak proč to nepoužít. Rozbít by to nic nemělo. V podstatě to není ani BC break.
```
$grid->addColumnText("message.author", "message.author", "message.author.name")
->setSortable('this->message->author->name')
```

Jen nápad :) Díky za odezvu