### PR TITLE
Sum support for Doctrine data source

### DIFF
--- a/src/AggregationFunction/FunctionSum.php
+++ b/src/AggregationFunction/FunctionSum.php
@@ -61,8 +61,11 @@ class FunctionSum implements IAggregationFunction
 		}
 		if ($data_source instanceof \Doctrine\ORM\QueryBuilder) {
 			$data_source_clone = clone $data_source;
+			$column = \Nette\Utils\Strings::contains($this->column, '.')
+				? $this->column 
+				: current($data_source_clone->getRootAliases()).'.'.$this->column;
 			$this->result = $data_source_clone
-				->select('SUM('.$this->column.')')
+				->select(sprintf('SUM(%s)', $column))
 				->getQuery()
 				->getSingleScalarResult();
 		}

--- a/src/AggregationFunction/FunctionSum.php
+++ b/src/AggregationFunction/FunctionSum.php
@@ -21,13 +21,19 @@ class FunctionSum implements IAggregationFunction
 	 */
 	protected $result = 0;
 
+	/**
+	 * @var int
+	 */
+	protected $dataType;
 
 	/**
 	 * @param string $column
+	 * @param int $dataType
 	 */
-	public function __construct($column)
+	public function __construct($column, $dataType = IAggregationFunction::DATA_TYPE_PAGINATED)
 	{
 		$this->column = $column;
+		$this->dataType = $dataType;
 	}
 
 
@@ -36,7 +42,7 @@ class FunctionSum implements IAggregationFunction
 	 */
 	public function getFilterDataType()
 	{
-		return IAggregationFunction::DATA_TYPE_PAGINATED;
+		return $this->dataType;
 	}
 
 
@@ -52,6 +58,13 @@ class FunctionSum implements IAggregationFunction
 				->from($data_source, 's')
 				->fetch()
 				->sum;
+		}
+		if ($data_source instanceof \Doctrine\ORM\QueryBuilder) {
+			$data_source_clone = clone $data_source;
+			$this->result = $data_source_clone
+				->select('SUM('.$this->column.')')
+				->getQuery()
+				->getSingleScalarResult();
 		}
 	}
 

--- a/src/AggregationFunction/FunctionSum.php
+++ b/src/AggregationFunction/FunctionSum.php
@@ -60,7 +60,6 @@ class FunctionSum implements IAggregationFunction
 				->sum;
 		}
 		if ($data_source instanceof \Doctrine\ORM\QueryBuilder) {
-			$originalSelect = $data_source->getDQLPart('select');
 			$column = \Nette\Utils\Strings::contains($this->column, '.')
 				? $this->column 
 				: current($data_source->getRootAliases()).'.'.$this->column;
@@ -68,7 +67,6 @@ class FunctionSum implements IAggregationFunction
 				->select(sprintf('SUM(%s)', $column))
 				->getQuery()
 				->getSingleScalarResult();
-			$data_source->add('select', $originalSelect, false);
 		}
 	}
 

--- a/src/AggregationFunction/FunctionSum.php
+++ b/src/AggregationFunction/FunctionSum.php
@@ -60,14 +60,15 @@ class FunctionSum implements IAggregationFunction
 				->sum;
 		}
 		if ($data_source instanceof \Doctrine\ORM\QueryBuilder) {
-			$data_source_clone = clone $data_source;
+			$originalSelect = $data_source->getDQLPart('select');
 			$column = \Nette\Utils\Strings::contains($this->column, '.')
 				? $this->column 
-				: current($data_source_clone->getRootAliases()).'.'.$this->column;
-			$this->result = $data_source_clone
+				: current($data_source->getRootAliases()).'.'.$this->column;
+			$this->result = $data_source
 				->select(sprintf('SUM(%s)', $column))
 				->getQuery()
 				->getSingleScalarResult();
+			$data_source->add('select', $originalSelect, false);
 		}
 	}
 

--- a/src/DataSource/DoctrineDataSource.php
+++ b/src/DataSource/DoctrineDataSource.php
@@ -367,7 +367,7 @@ class DoctrineDataSource extends FilterableDataSource implements IDataSource
 	*/
 	public function processAggregation(callable $aggregationCallback)
 	{
-		call_user_func($aggregationCallback, $this->data_source);
+		call_user_func($aggregationCallback, clone $this->data_source);
 	}
 
 }


### PR DESCRIPTION
- Added Doctrine QueryBuilder as possible source.
- Optional filter data type (doctrine supported) 
Example usage:
`$grid->addAggregationFunction('price', new FunctionSum('u.price', IAggregationFunction::DATA_TYPE_FILTERED));`
or
`$grid->addAggregationFunction('price', new FunctionSum('u.price', IAggregationFunction::DATA_TYPE_ALL));`