### PR TITLE
Typo in doc: replace walkaround with workaround

### DIFF
--- a/src/templates/datagrid.latte
+++ b/src/templates/datagrid.latte
@@ -4,7 +4,7 @@
  * @param Export[]        $exports            Available exports
  * @param Filter[]        $filters            Available filters
  * @param ToolBarButton[] $toolbar_buttons    Available toolbar_buttons
- * @param Form            $filter             Walkaround for latte snippets
+ * @param Form            $filter             Workaround for latte snippets
  * @param Row[]           $rows               List of rows (each contain a item from data source)
  * @param DataGrid        $control            Parent (DataGrid)
  * @param string          $original_template  Original template file path


### PR DESCRIPTION
According to Cambridge Online Dictionary, there is no [walkaround](http://dictionary.cambridge.org/spellcheck/english/?q=walkaround), but there is a [workaround](http://dictionary.cambridge.org/dictionary/english/workaround).