### PR TITLE
Send payload as JSON from handleEdit

### DIFF
--- a/src/DataGrid.php
+++ b/src/DataGrid.php
@@ -2459,6 +2459,7 @@ class DataGrid extends Nette\Application\UI\Control
 		$new_value = call_user_func_array($column->getEditableCallback(), [$id, $value]);
 
 		$this->getPresenter()->payload->_datagrid_editable_new_value = $new_value;
+		$this->getPresenter()->sendJson($this->getPresenter()->payload);
 	}
 
 


### PR DESCRIPTION
Hi, I have problem, when I´m using editable cols. In payload is not property  `_datagrid_editable_new_valuecallback`, but I receive whole HTML page of current view. So I edit this handle and I´m sending payload manually as json.