### PR TITLE
Update GroupActionCollection.php

### DIFF
--- a/src/GroupAction/GroupActionCollection.php
+++ b/src/GroupAction/GroupActionCollection.php
@@ -15,7 +15,7 @@ use Ublaboo\DataGrid\Exception\DataGridGroupActionException;
 
 class GroupActionCollection extends Nette\Object
 {
-	public const ID_ATTRIBUTE_PREFIX = 'group_action_item_';
+	const ID_ATTRIBUTE_PREFIX = 'group_action_item_';
 
 	/**
 	 * @var GroupAction[]


### PR DESCRIPTION
na PHP/7.0.18

syntax error, unexpected 'const' (T_CONST), expecting variable (T_VARIABLE)