### PR TITLE
Datagrid.js: fix datagridGroupActionMultiSelect() when not using selectpicker

### DIFF
--- a/assets/dist/datagrid.js
+++ b/assets/dist/datagrid.js
@@ -676,6 +676,9 @@ $(function() {
 });
 
 datagridGroupActionMultiSelect = function() {
+  if (!$.fn.selectpicker) {
+    return;
+  }
   var selects;
   selects = $('[data-datagrid-multiselect-id]');
   return selects.each(function() {
@@ -711,9 +714,7 @@ $.nette.ext('datagrid.fitlerMultiSelect', {
 
 $.nette.ext('datagrid.groupActionMultiSelect', {
   success: function() {
-    if ($.fn.selectpicker) {
-      return datagridGroupActionMultiSelect();
-    }
+    return datagridGroupActionMultiSelect();
   }
 });
 

--- a/assets/src/datagrid.coffee
+++ b/assets/src/datagrid.coffee
@@ -641,6 +641,9 @@ $ ->
 
 
 datagridGroupActionMultiSelect = ->
+	if !$.fn.selectpicker
+		return;
+
 	selects = $('[data-datagrid-multiselect-id]');
 
 	selects.each ->
@@ -672,8 +675,7 @@ $.nette.ext('datagrid.fitlerMultiSelect', {
 
 $.nette.ext('datagrid.groupActionMultiSelect', {
 	success: ->
-		if $.fn.selectpicker
-			datagridGroupActionMultiSelect()
+		datagridGroupActionMultiSelect()
 })
 
 


### PR DESCRIPTION
When not using selectpicker do not remove id from group action multiselect. Events `loaded.bs.select`/`rendered.bs.select` are never called and thus nette forms won`t toggle multiselect visibility.