### PR TITLE
Fix for non-functional text filter in PostgreSQL + dibi

### DIFF
--- a/src/DataModel.php
+++ b/src/DataModel.php
@@ -71,6 +71,9 @@ final class DataModel extends Nette\Object
 			} elseif ($driver instanceof Dibi\Drivers\MsSqlDriver) {
 				$source = new DataSource\DibiFluentMssqlDataSource($source, $primary_key);
 
+			} elseif ($driver instanceof Dibi\Drivers\PostgreDriver) {
+				$source = new DataSource\DibiFluentPostgreDataSource($source, $primary_key);
+
 			} elseif ($driver instanceof Dibi\Drivers\SqlsrvDriver) {
 				$source = new DataSource\DibiFluentMssqlDataSource($source, $primary_key);
 

--- a/src/DataSource/DibiFluentPostgreDataSource.php
+++ b/src/DataSource/DibiFluentPostgreDataSource.php
@@ -11,7 +11,6 @@ namespace Ublaboo\DataGrid\DataSource;
 use Dibi;
 use DibiFluent;
 use Ublaboo\DataGrid\Filter;
-use Ublaboo\DataGrid\Utils\DateTimeHelper;
 
 class DibiFluentPostgreDataSource extends DibiFluentDataSource
 {

--- a/src/DataSource/DibiFluentPostgreDataSource.php
+++ b/src/DataSource/DibiFluentPostgreDataSource.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * @copyright   Copyright (c) 2015 ublaboo <ublaboo@paveljanda.com>
+ * @author      Pavel Janda <me@paveljanda.com>
+ * @package     Ublaboo
+ */
+
+namespace Ublaboo\DataGrid\DataSource;
+
+use Dibi;
+use DibiFluent;
+use Ublaboo\DataGrid\Filter;
+use Ublaboo\DataGrid\Utils\DateTimeHelper;
+
+class DibiFluentPostgreDataSource extends DibiFluentDataSource
+{
+	/**
+	 * Filter by keyword
+	 * @param  Filter\FilterText $filter
+	 * @return void
+	 */
+	public function applyFilterText(Filter\FilterText $filter)
+	{
+		$condition = $filter->getCondition();
+		$driver = $this->data_source->getConnection()->getDriver();
+		$or = [];
+
+		foreach ($condition as $column => $value) {
+
+			$column = '[' . $column . ']';
+
+			if ($filter->isExactSearch()) {
+				$this->data_source->where("$column = %s", $value);
+				continue;
+			}
+
+			if ($filter->hasSplitWordsSearch() === false) {
+				$words = [$value];
+			} else {
+				$words = explode(' ', $value);
+			}
+
+			foreach ($words as $word) {
+				$escaped = $driver->escapeLike($word, 0);
+				$or[] = "$column ILIKE $escaped";
+			}
+		}
+
+		if (sizeof($or) > 1) {
+			$this->data_source->where('(%or)', $or);
+		} else {
+			$this->data_source->where($or);
+		}
+	}
+}


### PR DESCRIPTION
Fixes issue #496 + noted problem in Datagrid thread on Nette forum.

Created suggested DibiFluentPostgreDataSource with few modifications:
* avoid db specific escape of column name - use dibi quotation
* use ILIKE for fulltext search (PostgreSQL specific for case insensitive search)

