### PR TITLE
disable validations when changing per page

### DIFF
--- a/src/DataGrid.php
+++ b/src/DataGrid.php
@@ -1629,7 +1629,8 @@ class DataGrid extends Nette\Application\UI\Control
 			$form['per_page']->setValue($this->getPerPage());
 		}
 
-		$form->addSubmit('per_page_submit', 'ublaboo_datagrid.per_page_submit');
+		$form->addSubmit('per_page_submit', 'ublaboo_datagrid.per_page_submit')
+			->setValidationScope([$form['per_page']]);
 
 		$form->onSubmit[] = [$this, 'filterSucceeded'];
 	}


### PR DESCRIPTION
When new row or edit row forms are visible, changing per-page setting currently triggers their validation. This in turn prevents changing per-page setting.

My modification fixes it by specifically setting a validation scope on the per-page submit button.

P.S. We spoke about this when we met on Nette Camp this summer.