### PR TITLE
Fix DibiFluentDataSource like issue

### DIFF
--- a/src/DataSource/DibiFluentDataSource.php
+++ b/src/DataSource/DibiFluentDataSource.php
@@ -185,8 +185,7 @@ class DibiFluentDataSource extends FilterableDataSource implements IDataSource, 
 			}
 
 			foreach ($words as $word) {
-				$escaped = $driver->escapeLike($word, 0);
-				$or[] = "$column LIKE $escaped";
+				$or[] = ["$column LIKE %~like~", $word];
 			}
 		}
 


### PR DESCRIPTION
https://github.com/ublaboo/datagrid/issues/589

The problem was double escaping and it's only reasonable to leave all escaping to dibi (and not input escaped queries to it). I didn't fix this for PostgreSQL or MS SQL variants since I have no experience with them.