### PR TITLE
Fix: SmartObject is in nette/utils 2.4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
 	"require": {
 		"php": "^5.6|^7.0",
 		"nette/application": "^2.3",
-		"nette/utils": ">=2.3.10",
+		"nette/utils": ">=2.4.0",
 		"nette/forms": "^2.3",
 		"ublaboo/responses": "~1.0.0",
 		"symfony/property-access": "~3.0"


### PR DESCRIPTION
SmartObject is in nette/utils 2.4.0 (https://github.com/nette/utils/releases/tag/v2.4.0). It is not in version 2.3.10 so that require is not enough.