### PR TITLE
Empty values are not sending

### DIFF
--- a/assets/src/datagrid.coffee
+++ b/assets/src/datagrid.coffee
@@ -236,8 +236,8 @@ datagridSortable = ->
 			component_prefix = row.closest('.datagrid').find('tbody').attr('data-sortable-parent-path')
 
 			data[(component_prefix + '-item_id').replace(/^-/, '')] = item_id
-			data[(component_prefix + '-prev_id').replace(/^-/, '')] = prev_id
-			data[(component_prefix + '-next_id').replace(/^-/, '')] = next_id
+			if (prev_id !== null) data[(component_prefix + '-prev_id').replace(/^-/, '')] = prev_id
+			if (next_id !== null) data[(component_prefix + '-next_id').replace(/^-/, '')] = next_id
 
 			$.nette.ajax({
 				type: 'GET',
@@ -302,8 +302,8 @@ if typeof datagridSortableTree == 'undefined'
 				data = {}
 
 				data[(component_prefix + '-item_id').replace(/^-/, '')] = item_id
-				data[(component_prefix + '-prev_id').replace(/^-/, '')] = prev_id
-				data[(component_prefix + '-next_id').replace(/^-/, '')] = next_id
+				if (prev_id !== null) data[(component_prefix + '-prev_id').replace(/^-/, '')] = prev_id
+				if (next_id !== null) data[(component_prefix + '-next_id').replace(/^-/, '')] = next_id
 				data[(component_prefix + '-parent_id').replace(/^-/, '')] = parent_id
 
 				$.nette.ajax({


### PR DESCRIPTION
When using PHP 7.1 types empty arguments throw an error due to bad type conversion from empty string to int. They must be not sent

`public function handleSort(?int $item_id = NULL, ?int $prev_id = NULL, ?int $next_id = NULL)`