### PR TITLE
Toolbar buttons in treeview

### DIFF
--- a/src/templates/datagrid_tree.latte
+++ b/src/templates/datagrid_tree.latte
@@ -13,6 +13,11 @@
 <div class="datagrid-tree-item-children datagrid-tree" n:snippet="table" n:block="data" {if $control->isSortable()}data-sortable-tree data-sortable-url="{plink $control->getSortableHandler()}" data-sortable-parent-path="{$control->getSortableParentPath()}"{/if}>
 	{snippetArea items}
 		<div class="datagrid-tree-item datagrid-tree-header" n:snippet="item-header">
+			<div class="text-right" n:if="$control->canHideColumns() || $inlineAdd || $exports || $toolbar_buttons">
+				<span n:if="$toolbar_buttons">
+					{foreach $toolbar_buttons as $toolbar_button}{$toolbar_button->renderButton()}{/foreach}
+				</span>
+			</div>
 			<div class="datagrid-tree-item-content" data-has-children="">
 				<div class="datagrid-tree-item-left">
 					{foreach $columns as $key => $column}


### PR DESCRIPTION
Hi, this simple PR adds toolbar buttons to tree view template.

I am wondering why isnt treeview also in rendered as table but uses div layout - which is ofc incompatible with table. It completely blocks reusing blocks from parent tempalate - such as odering and filtering - it is all working (for NTDB) when included from parent template, bud disabled for treeview. 

I would create PR for ordering and filtering also, but I dont have much time to spare ATM.