### PR TITLE
Fix for doctrine/orm 3 (Expr::like param must be string)

### DIFF
--- a/src/DataSource/DoctrineDataSource.php
+++ b/src/DataSource/DoctrineDataSource.php
@@ -311,7 +311,7 @@ class DoctrineDataSource extends FilterableDataSource implements IDataSource, IA
 
 			foreach ($words as $word) {
 				$exprs[] = $this->dataSource->expr()->like(
-					$this->dataSource->expr()->lower($c),
+					(string) $this->dataSource->expr()->lower($c),
 					$this->dataSource->expr()->lower(
 						$this->dataSource->expr()->literal("%$word%")
 					)


### PR DESCRIPTION
Also works in doctrine 2, doctrine 3 has just added type in method.

It is already fixed in master, but not in 6.x.