### PR TITLE
fix for: Constant "Identifier" does not exist on class "Dibi\Fluent"

### DIFF
--- a/src/DataSource/DibiFluentDataSource.php
+++ b/src/DataSource/DibiFluentDataSource.php
@@ -171,7 +171,8 @@ class DibiFluentDataSource extends FilterableDataSource implements IDataSource, 
 		$or = [];
 
 		foreach ($condition as $column => $value) {
-			$column = Helpers::escape($driver, $column, Fluent::Identifier);
+			$column = Helpers::escape($driver, $column, \dibi::IDENTIFIER);
+
 
 			if ($filter->isExactSearch()) {
 				$this->dataSource->where(sprintf('%s = %%s', $column), $value);

--- a/src/DataSource/DibiFluentMssqlDataSource.php
+++ b/src/DataSource/DibiFluentMssqlDataSource.php
@@ -107,7 +107,7 @@ class DibiFluentMssqlDataSource extends DibiFluentDataSource
 		$or = [];
 
 		foreach ($condition as $column => $value) {
-			$column = Helpers::escape($driver, $column, Fluent::Identifier);
+			$column = Helpers::escape($driver, $column, \dibi::IDENTIFIER);
 
 			if ($filter->isExactSearch()) {
 				$this->dataSource->where(sprintf('%s = %%s', $column), $value);


### PR DESCRIPTION
Fix for: Constant "Identifier" does not exist on class "Dibi\Fluent"


Filtering text (using SQLite) is causing the following error.


```
$grid->addColumnLink('name', 'name', 'edit')
			->setSortable()
			->setFilterText();
```

![image](https://github.com/user-attachments/assets/b1392841-5ad4-4599-bdea-7e65052d469d)
