### PR TITLE
Update TButtonTryAddIcon.php

### DIFF
--- a/src/Traits/TButtonTryAddIcon.php
+++ b/src/Traits/TButtonTryAddIcon.php
@@ -17,7 +17,7 @@ trait TButtonTryAddIcon
 				$iconClass .= ' ' . Datagrid::$iconPrefix . $icon;
 			}
 
-			$el->addHtml(Html::el('span')->setAttribute('class', trim($iconClass)));
+			$el->addHtml(Html::el('i')->setAttribute('class', trim($iconClass)));
 
 			if (mb_strlen($name) > 1) {
 				$el->addHtml('&nbsp;');


### PR DESCRIPTION
Icons on buttons from the FontAwesome library didn’t work — they no longer use <span>, but <i>.