### PR TITLE
Prevent duplicate form submit for selectbox on inline edits

### DIFF
--- a/assets/plugins/features/editable.ts
+++ b/assets/plugins/features/editable.ts
@@ -108,7 +108,10 @@ export class EditablePlugin implements DatagridPlugin {
 							"input, textarea, select"
 						)
 						.forEach(el => {
-							el.addEventListener("blur", () => submitCell(el));
+							if (!(el instanceof HTMLSelectElement)) {
+								el.addEventListener("blur", () => submitCell(el));
+							}
+							
 							el.addEventListener("keydown", e => {
 								if (isEnter(e as KeyboardEvent)) {
 									e.stopPropagation();


### PR DESCRIPTION
Prevents duplicate form submit when code is edited with selectbox...
First update is triggered by on change and then on blur again... We do not need blur events for selects...
<img width="1279" height="493" alt="image" src="https://github.com/user-attachments/assets/35076ad1-8c52-4b38-b684-92b09640038f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved behavior of editable dropdown fields to prevent unintended submission triggers when interacting with select elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->