### PR TITLE
Add focus to input when opening small edit

### DIFF
--- a/assets/plugins/features/editable.ts
+++ b/assets/plugins/features/editable.ts
@@ -61,6 +61,8 @@ export class EditablePlugin implements DatagridPlugin {
 							input.setAttribute("value", valueToEdit);
 					}
 
+					input.focus();
+
 					const attributes = JSON.parse(cell.getAttribute(EditableAttrsAttribute) ?? "{}");
 					for (const key in attributes) {
 						const value = attributes[key];


### PR DESCRIPTION
fixes no focus issue for #1217

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced editing experience by automatically focusing the input field when editing begins, allowing users to immediately start typing without additional clicks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->