### PR TITLE
fix: add 'data-' prefix to EditableAttrsAttribute

### DIFF
--- a/assets/plugins/features/editable.ts
+++ b/assets/plugins/features/editable.ts
@@ -10,7 +10,7 @@ export const EditableElementAttribute = "data-datagrid-editable-element";
 
 export const EditableValueAttribute = "data-datagrid-editable-value";
 
-export const EditableAttrsAttribute = "datagrid-editable-attrs";
+export const EditableAttrsAttribute = "data-datagrid-editable-attrs";
 
 export class EditablePlugin implements DatagridPlugin {
 	onDatagridInit(datagrid: Datagrid): boolean {


### PR DESCRIPTION
This fixes incorrect EditableAttrsAttribute value in the EditablePlugin. It caused the plugin to ignore given attributes through `Column::setEditableInputType`.