### PR TITLE
Fix URL parameter handling for filtering and perPage changes (issue #…

### DIFF
--- a/src/Datagrid.php
+++ b/src/Datagrid.php
@@ -1383,7 +1383,14 @@ class Datagrid extends Control
 		}
 
 		$storedFilters = $this->getStorageData('_grid_filters', []);
+		$hasNonEmptyFilter = false;
+
 		foreach ($values as $key => $value) {
+			/**
+			 * Check if value is empty
+			 */
+			$isEmpty = is_iterable($value) ? ArraysHelper::testEmpty($value) : $value === '' || $value === null;
+
 			/**
 			 * Storage stuff
 			 */
@@ -1399,14 +1406,19 @@ class Datagrid extends Control
 			$storedFilters[(string) $key] = $value;
 
 			/**
-			 * Other stuff
+			 * Only add non-empty filters to the persistent parameter
 			 */
-			$this->filter[$key] = $value;
+			if (!$isEmpty) {
+				$this->filter[$key] = $value;
+				$hasNonEmptyFilter = true;
+			} else {
+				unset($this->filter[$key]);
+			}
 		}
 
 		$this->saveStorageData('_grid_filters', $storedFilters);
 
-		if ($values->count() > 0) {
+		if ($hasNonEmptyFilter) {
 			$this->saveStorageData('_grid_has_filtered', 1);
 		}
 


### PR DESCRIPTION
…1208)

Fixes issue #1208 where URL refreshing stopped working when using filtering or changing items per page. Only pagination via buttons was working.

The problem was that the filterSucceeded() method was adding ALL form filter values to the persistent $filter parameter, including empty ones. This caused URLs to include empty filter parameters like ?grid-filter[name]=, matching the reported regression from version 6.x.

Changes:
- Only non-empty filter values are now added to the persistent $filter parameter
- Empty filter values are explicitly unset from $filter
- The $hasNonEmptyFilter flag is now used to determine if filters are active, instead of just checking if values exist
- Empty filter values remain stored in session storage for recall, but don't appear in URL parameters

This ensures clean URLs and maintains feature parity with version 6.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)