### PR TITLE
Fix: Prevent AJAX requests from modifying browser history (#1210)

### DIFF
--- a/assets/ajax/naja.ts
+++ b/assets/ajax/naja.ts
@@ -118,7 +118,8 @@ export class NajaAjax<C extends Naja = Naja, G extends Datagrid = Datagrid> exte
 	}
 
 	async request<D = {}, P = DatagridPayload>(args: RequestParams<D>): Promise<P> {
-		return await this.client.makeRequest(args.method, args.url, args.data) as P;
+		const options = { history: false, ...args.options };
+		return await this.client.makeRequest(args.method, args.url, args.data ?? null, options) as P;
 	}
 
 	async submitForm<E extends HTMLFormElement = HTMLFormElement, P = Payload>(element: E): Promise<P> {

--- a/assets/types/ajax.d.ts
+++ b/assets/types/ajax.d.ts
@@ -7,7 +7,8 @@ export interface BaseRequestParams {
 }
 
 export interface RequestParams<D = any> extends BaseRequestParams {
-	data: D;
+	data?: D;
+	options?: Record<string, any>;
 }
 
 export interface DatagridPayload {


### PR DESCRIPTION
AJAX requests no longer modify the browser's history by default, preventing duplicate requests when users refresh the page after an AJAX operation.

Changes:
- Modified RequestParams to accept optional options parameter
- Updated NajaAjax.request() to set history: false by default
- Allows overriding history behavior if needed via options

🤖 Generated with Claude Code