### PR TITLE
Fix: Prevent AJAX requests from modifying browser history in datagrid…

### DIFF
--- a/assets/datagrid-full.ts
+++ b/assets/datagrid-full.ts
@@ -28,6 +28,7 @@ document.addEventListener("DOMContentLoaded", () => {
 		.forEach(el => new Dropdown(el))
 
 	// Initialize Naja (nette ajax)
+	naja.defaultOptions.history = false;
 	naja.formsHandler.netteForms = netteForms;
 	naja.initialize();
 


### PR DESCRIPTION
… initialization

Sets naja.defaultOptions.history = false to prevent unwanted browser history modifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

👀 #1210 