### PR TITLE
Fix Assets publish job on default branch pushes

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -25,6 +25,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: [build]
+    if: github.event_name == 'workflow_dispatch'
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary
- fix the default-branch `Assets` pipeline by preventing the `publish` job from running on regular `push` events
- keep package publishing available for manual runs via `workflow_dispatch`
- this avoids failing master pipelines when npm publish credentials are missing/invalid

## Root cause
The `publish` job was triggered on every push to `master` and executed `npm publish` with `secrets.NPM_TOKEN`. Recent default-branch runs failed in that step with npm registry auth errors, causing the whole Assets workflow to fail.

## Validation
- `gh run view 21982516272 --repo contributte/datagrid --log-failed` (shows failing `npm publish` auth step)
- `npm install && npm run build`