### PR TITLE
Fix: Hide filter row when all filterable columns are hidden (#1108)

### DIFF
--- a/src/templates/datagrid.latte
+++ b/src/templates/datagrid.latte
@@ -140,7 +140,7 @@
 						</th>
 					</tr>
 					<tr n:block="header-column-row">
-						<th n:snippet="thead-group-action" n:if="$hasGroupActions" n:attr="rowspan => !empty($filters) && !$control->hasOuterFilterRendering() ? 2" class="col-checkbox">
+						<th n:snippet="thead-group-action" n:if="$hasGroupActions" n:attr="rowspan => array_intersect_key($filters, $columns) && !$control->hasOuterFilterRendering() ? 2" class="col-checkbox">
 							<input n:if="$hasGroupActionOnRows" class="form-check-input" name="{$control->getFullName()|lower}-toggle-all" type="checkbox" data-check="{$control->getFullName()}" data-check-all="{$control->getFullName()}">
 						</th>
 						{foreach $columns as $key => $column}
@@ -199,7 +199,7 @@
 							{='contributte_datagrid.action'|translate}
 						</th>
 					</tr>
-					<tr n:block="header-filters" n:if="!empty($filters) && !$control->hasOuterFilterRendering()">
+					<tr n:block="header-filters" n:if="array_intersect_key($filters, $columns) && !$control->hasOuterFilterRendering()">
 						{foreach $columns as $key => $column}
 							{var $th = $column->getElementForRender('th', $key)}
 							{$th->startTag()|noescape}


### PR DESCRIPTION
Replace !empty(\$filters) with array_intersect_key(\$filters, \$columns) so the filter <tr> and group-action rowspan only render when at least one filter belongs to a currently visible column.

Closes  #1108