### PR TITLE
Add NetteDatabaseDataSource for raw SQL queries via Nette\Database\Explorer

### DIFF
--- a/src/DataSource/NetteDatabaseDataSource.php
+++ b/src/DataSource/NetteDatabaseDataSource.php
@@ -1,0 +1,313 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\Datagrid\DataSource;
+
+use Contributte\Datagrid\Exception\DatagridDateTimeHelperException;
+use Contributte\Datagrid\Filter\FilterDate;
+use Contributte\Datagrid\Filter\FilterDateRange;
+use Contributte\Datagrid\Filter\FilterMultiSelect;
+use Contributte\Datagrid\Filter\FilterRange;
+use Contributte\Datagrid\Filter\FilterSelect;
+use Contributte\Datagrid\Filter\FilterText;
+use Contributte\Datagrid\Utils\DateTimeHelper;
+use Contributte\Datagrid\Utils\Sorting;
+use Nette\Database\Explorer;
+use Nette\Database\ResultSet;
+
+class NetteDatabaseDataSource extends FilterableDataSource implements IDataSource
+{
+
+	protected array $data = [];
+
+	/** @var mixed[] */
+	protected array $queryParameters;
+
+	/** @var array<array{string, mixed[]}> */
+	protected array $whereConditions = [];
+
+	protected ?string $orderByClause = null;
+
+	/**
+	 * @param mixed[] $params
+	 */
+	public function __construct(
+		protected Explorer $connection,
+		protected string $sql,
+		array $params = [],
+	)
+	{
+		$this->queryParameters = $params;
+	}
+
+	public function getCount(): int
+	{
+		$sql = sprintf('SELECT COUNT(*) AS count FROM (%s) AS datagrid_count', $this->buildFilteredSql());
+
+		$row = $this->query($sql, $this->buildParams())->fetch();
+
+		return $row !== null ? (int) $row['count'] : 0;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getData(): array
+	{
+		return $this->data !== []
+			? $this->data
+			: $this->query($this->buildFinalSql(), $this->buildParams())->fetchAll();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function filterOne(array $condition): IDataSource
+	{
+		foreach ($condition as $column => $value) {
+			$this->addWhereCondition(sprintf('%s = ?', $column), [$value]);
+		}
+
+		return $this;
+	}
+
+	/**
+	 * @phpstan-param positive-int|0 $offset
+	 * @phpstan-param positive-int|0 $limit
+	 */
+	public function limit(int $offset, int $limit): IDataSource
+	{
+		$sql = sprintf('%s LIMIT %d OFFSET %d', $this->buildFinalSql(), $limit, $offset);
+
+		$this->data = $this->query($sql, $this->buildParams())->fetchAll();
+
+		return $this;
+	}
+
+	public function sort(Sorting $sorting): IDataSource
+	{
+		if (is_callable($sorting->getSortCallback())) {
+			call_user_func(
+				$sorting->getSortCallback(),
+				$this->sql,
+				$sorting->getSort()
+			);
+
+			return $this;
+		}
+
+		$sort = $sorting->getSort();
+
+		if ($sort !== []) {
+			$parts = [];
+
+			foreach ($sort as $column => $order) {
+				$parts[] = sprintf('%s %s', $column, $order);
+			}
+
+			$this->orderByClause = implode(', ', $parts);
+		}
+
+		return $this;
+	}
+
+	public function getDataSource(): Explorer
+	{
+		return $this->connection;
+	}
+
+	/**
+	 * Returns the current SQL query and its parameters.
+	 *
+	 * @return array{string, mixed[]}
+	 */
+	public function getQuery(): array
+	{
+		return [$this->buildFinalSql(), $this->buildParams()];
+	}
+
+	/**
+	 * @param mixed[] $params
+	 */
+	protected function addWhereCondition(string $sql, array $params = []): void
+	{
+		$this->whereConditions[] = [$sql, $params];
+	}
+
+	protected function buildFilteredSql(): string
+	{
+		if ($this->whereConditions === []) {
+			return $this->sql;
+		}
+
+		$whereParts = array_map(static fn (array $c): string => $c[0], $this->whereConditions);
+		$whereClause = implode(' AND ', $whereParts);
+
+		return sprintf('SELECT * FROM (%s) AS datagrid_base WHERE %s', $this->sql, $whereClause);
+	}
+
+	protected function buildFinalSql(): string
+	{
+		$sql = $this->buildFilteredSql();
+
+		if ($this->orderByClause !== null) {
+			$sql .= sprintf(' ORDER BY %s', $this->orderByClause);
+		}
+
+		return $sql;
+	}
+
+	/**
+	 * @return mixed[]
+	 */
+	protected function buildParams(): array
+	{
+		$params = $this->queryParameters;
+
+		foreach ($this->whereConditions as [, $conditionParams]) {
+			$params = array_merge($params, $conditionParams);
+		}
+
+		return $params;
+	}
+
+	/**
+	 * @param mixed[] $params
+	 * @return ResultSet<mixed>
+	 */
+	protected function query(string $sql, array $params = []): ResultSet
+	{
+		/** @phpstan-ignore argument.type */
+		return $this->connection->query($sql, ...$params);
+	}
+
+	protected function applyFilterDate(FilterDate $filter): void
+	{
+		$conditions = $filter->getCondition();
+
+		try {
+			$date = DateTimeHelper::tryConvertToDateTime($conditions[$filter->getColumn()], [$filter->getPhpFormat()]);
+
+			$this->addWhereCondition(
+				sprintf('DATE(%s) = ?', $filter->getColumn()),
+				[$date->format('Y-m-d')]
+			);
+		} catch (DatagridDateTimeHelperException) {
+			// ignore the invalid filter value
+		}
+	}
+
+	protected function applyFilterDateRange(FilterDateRange $filter): void
+	{
+		$conditions = $filter->getCondition();
+
+		$valueFrom = $conditions[$filter->getColumn()]['from'];
+		$valueTo = $conditions[$filter->getColumn()]['to'];
+
+		if ($valueFrom) {
+			try {
+				$dateFrom = DateTimeHelper::tryConvertToDateTime($valueFrom, [$filter->getPhpFormat()]);
+				$dateFrom->setTime(0, 0, 0);
+
+				$this->addWhereCondition(
+					sprintf('DATE(%s) >= ?', $filter->getColumn()),
+					[$dateFrom->format('Y-m-d')]
+				);
+			} catch (DatagridDateTimeHelperException) {
+				// ignore the invalid filter value
+			}
+		}
+
+		if ($valueTo) {
+			try {
+				$dateTo = DateTimeHelper::tryConvertToDateTime($valueTo, [$filter->getPhpFormat()]);
+				$dateTo->setTime(23, 59, 59);
+
+				$this->addWhereCondition(
+					sprintf('DATE(%s) <= ?', $filter->getColumn()),
+					[$dateTo->format('Y-m-d')]
+				);
+			} catch (DatagridDateTimeHelperException) {
+				// ignore the invalid filter value
+			}
+		}
+	}
+
+	protected function applyFilterRange(FilterRange $filter): void
+	{
+		$conditions = $filter->getCondition();
+
+		$valueFrom = $conditions[$filter->getColumn()]['from'];
+		$valueTo = $conditions[$filter->getColumn()]['to'];
+
+		if ($valueFrom !== '') {
+			$this->addWhereCondition(
+				sprintf('%s >= ?', $filter->getColumn()),
+				[$valueFrom]
+			);
+		}
+
+		if ($valueTo !== '') {
+			$this->addWhereCondition(
+				sprintf('%s <= ?', $filter->getColumn()),
+				[$valueTo]
+			);
+		}
+	}
+
+	protected function applyFilterText(FilterText $filter): void
+	{
+		$condition = $filter->getCondition();
+		$operator = $filter->hasConjunctionSearch() ? 'AND' : 'OR';
+		$or = [];
+		$bigOrArgs = [];
+
+		foreach ($condition as $column => $value) {
+			$like = '(';
+			$args = [];
+
+			if ($filter->isExactSearch()) {
+				$like .= sprintf('%s = ? %s ', $column, $operator);
+				$args[] = $value;
+			} else {
+				$words = $filter->hasSplitWordsSearch() === false ? [$value] : explode(' ', $value);
+
+				foreach ($words as $word) {
+					$like .= sprintf('%s LIKE ? %s ', $column, $operator);
+					$args[] = sprintf('%%%s%%', $word);
+				}
+			}
+
+			$like = substr($like, 0, strlen($like) - (strlen($operator) + 2)) . ')';
+
+			$or[] = $like;
+			$bigOrArgs = array_merge($bigOrArgs, $args);
+		}
+
+		if (count($or) > 1) {
+			$bigOr = '(' . implode(sprintf(' %s ', $operator), $or) . ')';
+			$this->addWhereCondition($bigOr, $bigOrArgs);
+		} else {
+			$this->addWhereCondition((string) reset($or), $bigOrArgs);
+		}
+	}
+
+	protected function applyFilterMultiSelect(FilterMultiSelect $filter): void
+	{
+		$condition = $filter->getCondition();
+		$values = $condition[$filter->getColumn()];
+
+		$placeholders = implode(', ', array_fill(0, count($values), '?'));
+		$this->addWhereCondition(
+			sprintf('%s IN (%s)', $filter->getColumn(), $placeholders),
+			array_values($values)
+		);
+	}
+
+	protected function applyFilterSelect(FilterSelect $filter): void
+	{
+		foreach ($filter->getCondition() as $column => $value) {
+			$this->addWhereCondition(sprintf('%s = ?', $column), [$value]);
+		}
+	}
+
+}

--- a/tests/Cases/DataSources/NetteDatabaseDataSourceTest.phpt
+++ b/tests/Cases/DataSources/NetteDatabaseDataSourceTest.phpt
@@ -1,0 +1,354 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\Datagrid\Tests\Cases\DataSources;
+
+use Contributte\Datagrid\DataSource\NetteDatabaseDataSource;
+use Contributte\Datagrid\Filter\FilterDate;
+use Contributte\Datagrid\Filter\FilterDateRange;
+use Contributte\Datagrid\Filter\FilterMultiSelect;
+use Contributte\Datagrid\Filter\FilterRange;
+use Contributte\Datagrid\Filter\FilterSelect;
+use Contributte\Datagrid\Filter\FilterText;
+use Contributte\Datagrid\Tests\Files\TestingDatagridFactory;
+use Contributte\Datagrid\Utils\Sorting;
+use Nette\Caching\Storages\DevNullStorage;
+use Nette\Database\Connection;
+use Nette\Database\Conventions\DiscoveredConventions;
+use Nette\Database\Explorer;
+use Nette\Database\Structure;
+use Tester\Assert;
+
+require __DIR__ . '/BaseDataSourceTest.phpt';
+
+final class NetteDatabaseDataSourceTest extends BaseDataSourceTest
+{
+
+	private Explorer $db;
+
+	public function setUp(): void
+	{
+		$this->setUpDatabase();
+		$this->ds = new NetteDatabaseDataSource($this->db, 'SELECT * FROM users');
+
+		$factory = new TestingDatagridFactory();
+		$this->grid = $factory->createTestingDatagrid();
+	}
+
+	public function testGetQueryFilterOne(): void
+	{
+		$s = new NetteDatabaseDataSource($this->db, 'SELECT * FROM users');
+		$s->filterOne(['id' => 1]);
+		[$sql, $params] = $s->getQuery();
+
+		Assert::same('SELECT * FROM (SELECT * FROM users) AS datagrid_base WHERE id = ?', $sql);
+		Assert::same([1], $params);
+	}
+
+	public function testGetQuerySort(): void
+	{
+		$s = new NetteDatabaseDataSource($this->db, 'SELECT * FROM users');
+		$s->sort(new Sorting(['name' => 'DESC']));
+		[$sql] = $s->getQuery();
+
+		Assert::same('SELECT * FROM users ORDER BY name DESC', $sql);
+	}
+
+	public function testGetQuerySortWithFilter(): void
+	{
+		$s = new NetteDatabaseDataSource($this->db, 'SELECT * FROM users');
+		$filter = new FilterSelect($this->grid, 'a', 'b', [1 => 'Active'], 'status');
+		$filter->setValue(1);
+		$s->filter([$filter]);
+		$s->sort(new Sorting(['name' => 'DESC']));
+		[$sql, $params] = $s->getQuery();
+
+		Assert::same('SELECT * FROM (SELECT * FROM users) AS datagrid_base WHERE status = ? ORDER BY name DESC', $sql);
+		Assert::same([1], $params);
+	}
+
+	public function testGetQueryFilterText(): void
+	{
+		$s = new NetteDatabaseDataSource($this->db, 'SELECT * FROM users');
+		$filter = new FilterText($this->grid, 'a', 'b', ['name']);
+		$filter->setValue('text');
+		$s->filter([$filter]);
+		[$sql, $params] = $s->getQuery();
+
+		Assert::same('SELECT * FROM (SELECT * FROM users) AS datagrid_base WHERE (name LIKE ?)', $sql);
+		Assert::same(['%text%'], $params);
+	}
+
+	public function testGetQueryFilterTextMultipleColumns(): void
+	{
+		$s = new NetteDatabaseDataSource($this->db, 'SELECT * FROM users');
+		$filter = new FilterText($this->grid, 'a', 'b', ['name', 'address']);
+		$filter->setValue('text');
+		$s->filter([$filter]);
+		[$sql, $params] = $s->getQuery();
+
+		Assert::same('SELECT * FROM (SELECT * FROM users) AS datagrid_base WHERE ((name LIKE ?) OR (address LIKE ?))', $sql);
+		Assert::same(['%text%', '%text%'], $params);
+	}
+
+	public function testGetQueryFilterTextSplitWords(): void
+	{
+		$s = new NetteDatabaseDataSource($this->db, 'SELECT * FROM users');
+		$filter = new FilterText($this->grid, 'a', 'b', ['name', 'address']);
+		$filter->setValue('foo bar');
+		$s->filter([$filter]);
+		[$sql, $params] = $s->getQuery();
+
+		Assert::same('SELECT * FROM (SELECT * FROM users) AS datagrid_base WHERE ((name LIKE ? OR name LIKE ?) OR (address LIKE ? OR address LIKE ?))', $sql);
+		Assert::same(['%foo%', '%bar%', '%foo%', '%bar%'], $params);
+	}
+
+	public function testGetQueryFilterTextSplitWordsDisabled(): void
+	{
+		$s = new NetteDatabaseDataSource($this->db, 'SELECT * FROM users');
+		$filter = new FilterText($this->grid, 'a', 'b', ['name', 'address']);
+		$filter->setValue('foo bar');
+		$filter->setSplitWordsSearch(false);
+		$s->filter([$filter]);
+		[$sql, $params] = $s->getQuery();
+
+		Assert::same('SELECT * FROM (SELECT * FROM users) AS datagrid_base WHERE ((name LIKE ?) OR (address LIKE ?))', $sql);
+		Assert::same(['%foo bar%', '%foo bar%'], $params);
+	}
+
+	public function testGetQueryFilterTextExactSearch(): void
+	{
+		$s = new NetteDatabaseDataSource($this->db, 'SELECT * FROM users');
+		$filter = new FilterText($this->grid, 'a', 'b', ['name', 'address']);
+		$filter->setExactSearch();
+		$filter->setValue('John');
+		$s->filter([$filter]);
+		[$sql, $params] = $s->getQuery();
+
+		Assert::same('SELECT * FROM (SELECT * FROM users) AS datagrid_base WHERE ((name = ?) OR (address = ?))', $sql);
+		Assert::same(['John', 'John'], $params);
+	}
+
+	public function testGetQueryFilterRange(): void
+	{
+		$s = new NetteDatabaseDataSource($this->db, 'SELECT * FROM users');
+		$filter = new FilterRange($this->grid, 'a', 'b', 'age', '-');
+		$filter->setValue(['from' => 10, 'to' => 50]);
+		$s->filter([$filter]);
+		[$sql, $params] = $s->getQuery();
+
+		Assert::same('SELECT * FROM (SELECT * FROM users) AS datagrid_base WHERE age >= ? AND age <= ?', $sql);
+		Assert::same([10, 50], $params);
+	}
+
+	public function testGetQueryFilterMultiSelect(): void
+	{
+		$s = new NetteDatabaseDataSource($this->db, 'SELECT * FROM users');
+		$filter = new FilterMultiSelect($this->grid, 'a', 'b', [1 => 'A', 2 => 'B'], 'status');
+		$filter->setValue([1, 2]);
+		$s->filter([$filter]);
+		[$sql, $params] = $s->getQuery();
+
+		Assert::same('SELECT * FROM (SELECT * FROM users) AS datagrid_base WHERE status IN (?, ?)', $sql);
+		Assert::same([1, 2], $params);
+	}
+
+	public function testGetQueryWithInitialParams(): void
+	{
+		$s = new NetteDatabaseDataSource($this->db, 'SELECT * FROM users WHERE active = ?', [1]);
+		$filter = new FilterSelect($this->grid, 'a', 'b', ['John Red' => 'John Red'], 'name');
+		$filter->setValue('John Red');
+		$s->filter([$filter]);
+		[$sql, $params] = $s->getQuery();
+
+		Assert::same('SELECT * FROM (SELECT * FROM users WHERE active = ?) AS datagrid_base WHERE name = ?', $sql);
+		Assert::same([1, 'John Red'], $params);
+	}
+
+	public function testGetDataSource(): void
+	{
+		$s = new NetteDatabaseDataSource($this->db, 'SELECT * FROM users');
+		Assert::same($this->db, $s->getDataSource());
+	}
+
+	public function testGetDataCached(): void
+	{
+		$s = new NetteDatabaseDataSource($this->db, 'SELECT * FROM users');
+		$s->limit(0, 3);
+		// Second call returns cached $this->data, not a new query
+		Assert::count(3, $s->getData());
+	}
+
+	public function testSortCallback(): void
+	{
+		$s = new NetteDatabaseDataSource($this->db, 'SELECT * FROM users');
+		$capture = new \stdClass();
+		$capture->sql = null;
+		$capture->sort = null;
+		$sorting = new Sorting(['name' => 'DESC'], static function (string $sql, array $sort) use ($capture): void {
+			$capture->sql = $sql;
+			$capture->sort = $sort;
+		});
+		$s->sort($sorting);
+
+		Assert::same('SELECT * FROM users', $capture->sql);
+		Assert::same(['name' => 'DESC'], $capture->sort);
+
+		// orderByClause stays null — callback is responsible for sorting
+		[$sql] = $s->getQuery();
+		Assert::same('SELECT * FROM users', $sql);
+	}
+
+	public function testSortEmptyArray(): void
+	{
+		$s = new NetteDatabaseDataSource($this->db, 'SELECT * FROM users');
+		$s->sort(new Sorting([]));
+		[$sql] = $s->getQuery();
+
+		// No ORDER BY added when sort array is empty
+		Assert::same('SELECT * FROM users', $sql);
+	}
+
+	public function testFilterDate(): void
+	{
+		$s = new NetteDatabaseDataSource($this->db, 'SELECT * FROM users');
+		$filter = new FilterDate($this->grid, 'a', 'b', 'created');
+		$filter->setValue('12. 12. 2012');
+		$s->filter([$filter]);
+		[$sql, $params] = $s->getQuery();
+
+		Assert::same('SELECT * FROM (SELECT * FROM users) AS datagrid_base WHERE DATE(created) = ?', $sql);
+		Assert::same(['2012-12-12'], $params);
+	}
+
+	public function testFilterDateInvalid(): void
+	{
+		$s = new NetteDatabaseDataSource($this->db, 'SELECT * FROM users');
+		$filter = new FilterDate($this->grid, 'a', 'b', 'created');
+		$filter->setValue('not-a-date');
+		$s->filter([$filter]);
+		[$sql, $params] = $s->getQuery();
+
+		// Invalid date is silently ignored — no condition added
+		Assert::same('SELECT * FROM users', $sql);
+		Assert::same([], $params);
+	}
+
+	public function testFilterDateRange(): void
+	{
+		$s = new NetteDatabaseDataSource($this->db, 'SELECT * FROM users');
+		$filter = new FilterDateRange($this->grid, 'a', 'b', 'created', '-');
+		$filter->setValue(['from' => '1. 2. 2003', 'to' => '3. 12. 2149']);
+		$s->filter([$filter]);
+		[$sql, $params] = $s->getQuery();
+
+		Assert::same('SELECT * FROM (SELECT * FROM users) AS datagrid_base WHERE DATE(created) >= ? AND DATE(created) <= ?', $sql);
+		Assert::same(['2003-02-01', '2149-12-03'], $params);
+	}
+
+	public function testFilterDateRangeOnlyFrom(): void
+	{
+		$s = new NetteDatabaseDataSource($this->db, 'SELECT * FROM users');
+		$filter = new FilterDateRange($this->grid, 'a', 'b', 'created', '-');
+		$filter->setValue(['from' => '1. 2. 2003', 'to' => '']);
+		$s->filter([$filter]);
+		[$sql, $params] = $s->getQuery();
+
+		Assert::same('SELECT * FROM (SELECT * FROM users) AS datagrid_base WHERE DATE(created) >= ?', $sql);
+		Assert::same(['2003-02-01'], $params);
+	}
+
+	public function testFilterDateRangeOnlyTo(): void
+	{
+		$s = new NetteDatabaseDataSource($this->db, 'SELECT * FROM users');
+		$filter = new FilterDateRange($this->grid, 'a', 'b', 'created', '-');
+		$filter->setValue(['from' => '', 'to' => '3. 12. 2149']);
+		$s->filter([$filter]);
+		[$sql, $params] = $s->getQuery();
+
+		Assert::same('SELECT * FROM (SELECT * FROM users) AS datagrid_base WHERE DATE(created) <= ?', $sql);
+		Assert::same(['2149-12-03'], $params);
+	}
+
+	public function testFilterDateRangeInvalidFrom(): void
+	{
+		$s = new NetteDatabaseDataSource($this->db, 'SELECT * FROM users');
+		$filter = new FilterDateRange($this->grid, 'a', 'b', 'created', '-');
+		$filter->setValue(['from' => 'invalid', 'to' => '3. 12. 2149']);
+		$s->filter([$filter]);
+		[$sql, $params] = $s->getQuery();
+
+		// Invalid from is silently ignored — only to condition added
+		Assert::same('SELECT * FROM (SELECT * FROM users) AS datagrid_base WHERE DATE(created) <= ?', $sql);
+		Assert::same(['2149-12-03'], $params);
+	}
+
+	public function testFilterDateRangeInvalidTo(): void
+	{
+		$s = new NetteDatabaseDataSource($this->db, 'SELECT * FROM users');
+		$filter = new FilterDateRange($this->grid, 'a', 'b', 'created', '-');
+		$filter->setValue(['from' => '1. 2. 2003', 'to' => 'invalid']);
+		$s->filter([$filter]);
+		[$sql, $params] = $s->getQuery();
+
+		// Invalid to is silently ignored — only from condition added
+		Assert::same('SELECT * FROM (SELECT * FROM users) AS datagrid_base WHERE DATE(created) >= ?', $sql);
+		Assert::same(['2003-02-01'], $params);
+	}
+
+	public function testFilterTextConjunctionMultipleColumns(): void
+	{
+		$s = new NetteDatabaseDataSource($this->db, 'SELECT * FROM users');
+		$filter = new FilterText($this->grid, 'a', 'b', ['name', 'address']);
+		$filter->setConjunctionSearch();
+		$filter->setValue('John');
+		$s->filter([$filter]);
+		[$sql, $params] = $s->getQuery();
+
+		Assert::same('SELECT * FROM (SELECT * FROM users) AS datagrid_base WHERE ((name LIKE ?) AND (address LIKE ?))', $sql);
+		Assert::same(['%John%', '%John%'], $params);
+	}
+
+	protected function setUpDatabase(): void
+	{
+		$connection = new Connection('sqlite::memory:');
+		$storage = new DevNullStorage();
+		$structure = new Structure($connection, $storage);
+		$conventions = new DiscoveredConventions($structure);
+		$this->db = new Explorer($connection, $structure, $conventions, $storage);
+
+		$this->db->query('CREATE TABLE users (
+			id      INTEGER      PRIMARY KEY AUTOINCREMENT,
+			name    VARCHAR (50),
+			age     INTEGER (3),
+			address VARCHAR (50)
+		)');
+
+		foreach ($this->data as $row) {
+			$this->db->query('INSERT INTO users', $row);
+		}
+	}
+
+	protected function getActualResultAsArray(): array
+	{
+		$data = $this->ds->getData();
+		$rows = [];
+
+		foreach ($data as $dataRow) {
+			$row = [];
+
+			foreach ($dataRow as $key => $value) {
+				$row[$key] = is_numeric($value)
+					? intval($value)
+					: $value;
+			}
+
+			$rows[] = $row;
+		}
+
+		return $rows;
+	}
+
+}
+
+$test_case = new NetteDatabaseDataSourceTest();
+$test_case->run();


### PR DESCRIPTION
Ports the [contributte/datagrid-nette-database-data-source](https://github.com/contributte/datagrid-nette-database-data-source) package into the main datagrid repository. Uses subquery wrapping for filter injection instead of PHPSQLParser, avoiding any extra dependencies.