### PR TITLE
Fix: TreeView icon swap + prevent getChildren on collapse

### DIFF
--- a/assets/css/datagrid.css
+++ b/assets/css/datagrid.css
@@ -351,7 +351,6 @@
 	text-align: center;
 	position: relative;
 	margin: 0 5px 0 -27px;
-	transition: transform 0.2s ease-in-out
 }
 
 [data-datagrid-name] .datagrid-tree .datagrid-tree-item .datagrid-tree-item-content .datagrid-tree-item-left > .chevron:hover {
@@ -360,13 +359,32 @@
 	box-shadow: 0px 0px 3px 0px #b4b4b4
 }
 
-[data-datagrid-name] .datagrid-tree .datagrid-tree-item .datagrid-tree-item-content .datagrid-tree-item-left > .chevron.toggle-rotate {
-	transform: rotate(90deg)
-}
-
 [data-datagrid-name] .datagrid-tree .datagrid-tree-item .datagrid-tree-item-content .datagrid-tree-item-left > .chevron .fa {
 	font-size: 10px;
 	transform: translate(1px, 0)
+}
+
+[data-datagrid-name] .datagrid-tree .datagrid-tree-item .datagrid-tree-item-content .datagrid-tree-item-left > .chevron [data-tree-icon="expanded"],
+[data-datagrid-name] .datagrid-tree .datagrid-tree-item .datagrid-tree-item-content .datagrid-tree-item-left > .chevron [data-tree-icon="loading"] {
+	display: none;
+}
+
+[data-datagrid-name] .datagrid-tree .datagrid-tree-item .datagrid-tree-item-content .datagrid-tree-item-left > .chevron.is-loading [data-tree-icon="collapsed"],
+[data-datagrid-name] .datagrid-tree .datagrid-tree-item .datagrid-tree-item-content .datagrid-tree-item-left > .chevron.is-loading [data-tree-icon="expanded"] {
+	display: none;
+}
+
+[data-datagrid-name] .datagrid-tree .datagrid-tree-item .datagrid-tree-item-content .datagrid-tree-item-left > .chevron.is-loading [data-tree-icon="loading"] {
+	display: inline-block;
+}
+
+[data-datagrid-name] .datagrid-tree .datagrid-tree-item .datagrid-tree-item-content .datagrid-tree-item-left > .chevron.is-expanded [data-tree-icon="collapsed"],
+[data-datagrid-name] .datagrid-tree .datagrid-tree-item .datagrid-tree-item-content .datagrid-tree-item-left > .chevron.is-expanded [data-tree-icon="loading"] {
+	display: none;
+}
+
+[data-datagrid-name] .datagrid-tree .datagrid-tree-item .datagrid-tree-item-content .datagrid-tree-item-left > .chevron.is-expanded [data-tree-icon="expanded"] {
+	display: inline-block;
 }
 
 [data-datagrid-name] .datagrid-tree .datagrid-tree-item .datagrid-tree-item-content .datagrid-tree-item-right {

--- a/assets/plugins/features/treeView.ts
+++ b/assets/plugins/features/treeView.ts
@@ -3,6 +3,26 @@ import { Datagrid } from "../..";
 
 export class TreeViewPlugin implements DatagridPlugin {
 	onDatagridInit(datagrid: Datagrid): boolean {
+		datagrid.ajax.addEventListener("interact", (event) => {
+			const element = event.detail.element;
+			if (!element.classList.contains('chevron')) return;
+
+			const rowBlock = element.closest<HTMLElement>('.datagrid-tree-item');
+			const childrenBlock = rowBlock?.querySelector<HTMLElement>('.datagrid-tree-item-children');
+
+			if (!childrenBlock) return;
+
+			if (childrenBlock.classList.contains('showed')) {
+				childrenBlock.innerHTML = '';
+				childrenBlock.classList.remove('showed');
+				element.classList.remove('is-expanded');
+				event.preventDefault();
+				return;
+			}
+
+			element.classList.add('is-loading');
+		});
+
 		datagrid.ajax.addEventListener("success", ({detail: {payload}}) => {
 			if (!payload._datagrid_tree) return;
 
@@ -12,18 +32,14 @@ export class TreeViewPlugin implements DatagridPlugin {
 
 			if (!childrenBlock) return;
 
-			const isExpanded = childrenBlock.classList.contains('showed');
-			const chevron = rowBlock?.querySelector<HTMLAnchorElement>('a.chevron');
-
-			if (isExpanded) {
-				childrenBlock.innerHTML = '';
-				childrenBlock.classList.remove('showed');
-				if (chevron) chevron.style.transform = "rotate(0deg)";
-				return;
-			}
+			const chevron = rowBlock?.querySelector<HTMLElement>('a.chevron');
 
 			childrenBlock.classList.add('showed');
-			if (chevron) chevron.style.transform = "rotate(90deg)";
+
+			if (chevron) {
+				chevron.classList.remove('is-loading');
+				chevron.classList.add('is-expanded');
+			}
 
 			const childrenHtml: string[] = [];
 			for (const snippetName in payload.snippets) {
@@ -39,7 +55,14 @@ export class TreeViewPlugin implements DatagridPlugin {
 			}
 
 			childrenBlock.innerHTML = childrenHtml.join('');
-		})
+		});
+
+		datagrid.ajax.addEventListener("error", () => {
+			document.querySelectorAll<HTMLElement>('a.chevron.is-loading').forEach((chevron) => {
+				chevron.classList.remove('is-loading');
+			});
+		});
+
 		return true;
 	}
 }

--- a/src/templates/datagrid_tree.latte
+++ b/src/templates/datagrid_tree.latte
@@ -66,7 +66,9 @@
 				<div n:class="datagrid-tree-item-content, $row->getControlClass()" data-id="{$row->getId()}" data-has-children="{$hasChildren ? true : false}">
 					<div class="datagrid-tree-item-left">
 						<a n:href="getChildren! parent => $row->getId()" data-bs-toggle-tree="true" n:class="!$hasChildren ? hidden, 'chevron ajax'">
-							<i n:block="icon-chevron" class="{$iconPrefix}chevron-right"></i>
+							<i n:block="icon-chevron-collapsed" data-tree-icon="collapsed" class="{$iconPrefix}chevron-right"></i>
+							<i n:block="icon-chevron-expanded" data-tree-icon="expanded" class="{$iconPrefix}chevron-down"></i>
+							<i n:block="icon-chevron-loading" data-tree-icon="loading" class="{$iconPrefix}spinner fa-spin"></i>
 						</a>
 						{foreach $columns as $key => $column}
 							{var $col = 'col-' . $key}


### PR DESCRIPTION
## Summary

- Replaces CSS `transform: rotate` with proper icon swapping (`chevron-right` → `chevron-down`)
- Adds a spinner/loading icon while `getChildren` AJAX request is in flight
- Prevents `handleGetChildren` from being called when closing the treeview (intercepts the `interact` event and cancels it)

Closes #578

## Changes

- `datagrid_tree.latte`: three icons in the chevron `<a>` (`collapsed`, `expanded`, `loading`), each with a `data-tree-icon` attribute
- `datagrid.css`: CSS visibility rules driven by `.is-loading` / `.is-expanded` state classes; removed dead `.toggle-rotate` and `transition: transform`
- `treeView.ts`: JS now only toggles state classes; no more icon prefix detection

## Test plan

- [ ] Click chevron on a row with children → spinner appears, then chevron-down when loaded
- [ ] Click chevron again on an expanded row → collapses immediately, no network request made
- [ ] Simulate AJAX error → spinner reverts to chevron-right

## Screenshot
<img width="239" height="124" alt="image" src="https://github.com/user-attachments/assets/a8bbe2a2-f86c-44c5-922a-663a4cf3be12" />
