### PR TITLE
Fix: Remove obsolete CSS vendor prefixes

### DIFF
--- a/assets/css/datagrid.css
+++ b/assets/css/datagrid.css
@@ -211,7 +211,6 @@
 
 [data-datagrid-name] .datagrid-col-filter-date-range > .input-group {
 	position: relative;
-	-ms-flex: 1 1 auto;
 	flex: 1 1 auto;
 	width: 1%;
 	margin-bottom: 0;
@@ -224,8 +223,6 @@
 }
 
 [data-datagrid-name] table thead tr th .datagrid-col-filter-range .form-control {
-	-webkit-border-radius: 3px;
-	-moz-border-radius: 3px;
 	border-radius: 3px
 }
 
@@ -339,8 +336,6 @@
 }
 
 [data-datagrid-name] .datagrid-tree .datagrid-tree-item .datagrid-tree-item-content .datagrid-tree-item-left > .chevron {
-	-webkit-border-radius: 11px;
-	-moz-border-radius: 11px;
 	border-radius: 11px;
 	width: 22px;
 	height: 22px;
@@ -355,8 +350,6 @@
 }
 
 [data-datagrid-name] .datagrid-tree .datagrid-tree-item .datagrid-tree-item-content .datagrid-tree-item-left > .chevron:hover {
-	-webkit-box-shadow: 0px 0px 3px 0px #b4b4b4;
-	-moz-box-shadow: 0px 0px 3px 0px #b4b4b4;
 	box-shadow: 0px 0px 3px 0px #b4b4b4
 }
 
@@ -557,9 +550,6 @@
 [data-datagrid-name] .col-checkbox {
 	-webkit-touch-callout: none;
 	-webkit-user-select: none;
-	-khtml-user-select: none;
-	-moz-user-select: none;
-	-ms-user-select: none;
 	user-select: none
 }
 


### PR DESCRIPTION
Remove -webkit-border-radius, -moz-border-radius, -webkit-box-shadow, -moz-box-shadow, -ms-flex, -khtml-user-select, -moz-user-select and -ms-user-select prefixes. Keep -webkit-user-select and -webkit-touch-callout for Safari/iOS support.