### PR TITLE
Fix: abort previous filter request on new keystroke

### DIFF
--- a/assets/utils.ts
+++ b/assets/utils.ts
@@ -121,21 +121,11 @@ export function debounce<TArgs, TFun extends (...args: TArgs[]) => unknown | Pro
 	slowdown: number = 200
 ): (...args: TArgs[]) => void {
 	let timeout: ReturnType<typeof setTimeout> | null = null;
-	let blockedByPromise: boolean = false;
 
 	return (...args) => {
-		if (blockedByPromise) return;
-
 		timeout && clearTimeout(timeout);
 		timeout = setTimeout(() => {
-			const result = fn(...args);
-
-			if (isPromise(result)) {
-				blockedByPromise = true;
-				result.finally(() => {
-					blockedByPromise = false;
-				});
-			}
+			fn(...args);
 		}, slowdown);
 	};
 }

--- a/src/templates/datagrid.latte
+++ b/src/templates/datagrid.latte
@@ -17,7 +17,7 @@
 <div class="{block datagrid-class}datagrid{/block}" data-datagrid-name="{$control->getFullName()}" data-refresh-state="{link refreshState!}">
 	<div n:snippet="grid">
 	{snippetArea gridSnippets}
-		{form filter, class => 'ajax'}
+		{form filter, class => 'ajax', data-naja-unique => "datagrid-filter-{$control->getFullName()}"}
 			{if $control->hasOuterFilterRendering()}
 				{block outer-filters}
 					<div class="row text-end datagrid-collapse-filters-button-row" n:if="$control->hasCollapsibleOuterFilters()">


### PR DESCRIPTION
## Summary

The autosubmit filter has two issues that cause poor UX when typing in filter inputs:

### 1. Keystrokes dropped during pending request

The `debounce()` utility in `utils.ts` uses a `blockedByPromise` mechanism — when a request is in flight, **all new keystrokes are silently discarded** (not deferred). If the server takes longer than 200ms, the user types "abc" but gets results for "a" because "b" and "c" were dropped.

**Fix:** Removed `blockedByPromise` from `debounce()`. The timer simply resets on each call, so the latest value is always submitted after the 200ms delay.

### 2. Previous filter requests not aborted

When typing slowly (>200ms between keystrokes), each keystroke triggers a separate AJAX request. Previous requests continue running and their responses may arrive out of order, causing the datagrid to display stale results.

**Fix:** Added `data-naja-unique` attribute to the filter `<form>` tag in `datagrid.latte`. Naja 3's built-in `UniqueExtension` (registered by default) uses this attribute to automatically abort the previous request when a new one starts from the same form. The unique key includes the datagrid's full name to support multiple datagrids on one page.

## Test plan

- [ ] Type quickly into a filter input — only one request should fire (debounce groups keystrokes)
- [ ] Type slowly (>200ms between chars) — each keystroke fires a request, but previous requests are aborted (visible as cancelled in Network tab)
- [ ] Test with slow server response — final result should always match the latest typed value
- [ ] Test with multiple datagrids on one page — filter abort should be independent per datagrid
- [ ] Test select filters (e.g. status dropdown) — should still work as before
- [ ] Test `data-autosubmit-change` inputs — should still work as before