### PR TITLE
chore: migrate coverage reporting to Codecov

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,9 +13,35 @@ on:
 jobs:
   coverage:
     name: "Nette Tester"
-    uses: contributte/.github/.github/workflows/nette-tester-mysql.yml@v1
-    with:
-      php: "8.5"
-      database: tests
-      coverage: true
-      make: coverage
+    runs-on: "ubuntu-latest"
+
+    services:
+      mysql:
+        image: "mysql:5.7"
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: true
+          MYSQL_DATABASE: "tests"
+        ports:
+          - 3306:3306
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v4"
+
+      - name: "PHP"
+        uses: "contributte/.github/.github/actions/setup-php@master"
+        with:
+          php: "8.5"
+
+      - name: "Composer"
+        uses: "contributte/.github/.github/actions/setup-composer@master"
+        with:
+          command: "composer install --no-interaction --no-progress --prefer-dist"
+
+      - name: "Run Nette Tester"
+        run: "make coverage"
+
+      - name: "Codecov"
+        uses: "codecov/codecov-action@v4"
+        env:
+          CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align=center>
 	<a href="https://github.com/contributte/datagrid/actions"><img src="https://badgen.net/github/checks/contributte/datagrid/master"></a>
-	<a href="https://coveralls.io/r/contributte/datagrid"><img src="https://badgen.net/coveralls/c/github/contributte/datagrid"></a>
+	<a href="https://codecov.io/gh/contributte/datagrid"><img src="https://badgen.net/codecov/c/github/contributte/datagrid"></a>
 	<a href="https://packagist.org/packages/ublaboo/datagrid"><img src="https://badgen.net/packagist/dm/ublaboo/datagrid"></a>
 	<a href="https://packagist.org/packages/ublaboo/datagrid"><img src="https://badgen.net/packagist/v/ublaboo/datagrid"></a>
 </p>

--- a/tests/.coveralls.yml
+++ b/tests/.coveralls.yml
@@ -1,4 +1,0 @@
-# for php-coveralls
-service_name: github-actions
-coverage_clover: coverage.xml
-json_path: coverage.json


### PR DESCRIPTION
Closes contributte/contributte#72.

## What changed
- switched the README coverage badge from Coveralls to Codecov
- replaced the Coveralls-based coverage job with an inline GitHub Actions workflow that still boots MySQL and uploads coverage to Codecov
- removed `tests/.coveralls.yml`, which is no longer used after the migration

## Why
- this finishes the remaining Coveralls-to-Codecov migration for `contributte/datagrid` without dropping the database-backed coverage run the repository already needs