### PR TITLE
Remove phpdbg from coverage target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ tests:
 
 coverage:
 ifdef GITHUB_ACTION
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
 else
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
 endif


### PR DESCRIPTION
## Summary

Replace `phpdbg` with `php` in the `coverage` Makefile target so coverage runs use the regular PHP binary.

## Motivation

Issue #73 tracks removing `phpdbg` from Contributte coverage targets while keeping coverage generation working with supported drivers.

## Changes

- switch both `coverage` target variants in `Makefile` from `-p phpdbg` to `-p php`
- keep the existing coverage output paths and source configuration unchanged

## Testing

- [x] `composer install`
- [ ] `make coverage` locally
- [ ] CI passes

`make coverage` currently fails in this environment because `php` has no Xdebug or PCOV extension loaded, so coverage cannot be generated after removing the PHPDBG runner.