### PR TITLE
Fix: Use event delegation for confirm to survive AJAX snippet updates

### DIFF
--- a/assets/plugins/features/confirm.ts
+++ b/assets/plugins/features/confirm.ts
@@ -32,8 +32,13 @@ export class ConfirmPlugin implements DatagridPlugin {
 	onDatagridInit(datagrid: Datagrid): boolean {
 		this.datagrid = datagrid;
 
-		const confirmElements = datagrid.el.querySelectorAll<HTMLElement>(`[${ConfirmAttribute}]:not(.ajax)`);
-		confirmElements.forEach(el => el.addEventListener("click", e => this.handleClick(el, e)));
+		datagrid.el.addEventListener("click", e => {
+			const target = e.target as HTMLElement;
+			const confirmEl = target.closest<HTMLElement>(`[${ConfirmAttribute}]:not(.ajax)`);
+			if (confirmEl) {
+				this.handleClick(confirmEl, e);
+			}
+		});
 
 		datagrid.ajax.addEventListener("interact", e => {
 			const target = e.detail.element;


### PR DESCRIPTION
## Summary

- Fixes `data-datagrid-confirm` dialog not showing after a filter is applied (#1250)
- Direct click listeners were attached to confirm elements at init time; after AJAX snippet updates, those elements are replaced with fresh DOM nodes and the listeners are lost
- Replaced with a single delegated listener on `datagrid.el`, which persists across snippet updates

## Test plan

- [ ] Open a datagrid with a confirm action button
- [ ] Apply a text or select filter
- [ ] Click the confirm button — dialog should appear as expected

Closes #1250