### PR TITLE
Fix: MSSQL text filter double N-prefix (NN'...') with Dibi 4.1+

### DIFF
--- a/src/DataSource/DibiFluentMssqlDataSource.php
+++ b/src/DataSource/DibiFluentMssqlDataSource.php
@@ -5,10 +5,8 @@ namespace Contributte\Datagrid\DataSource;
 use Contributte\Datagrid\Exception\DatagridDateTimeHelperException;
 use Contributte\Datagrid\Filter\FilterDate;
 use Contributte\Datagrid\Filter\FilterDateRange;
-use Contributte\Datagrid\Filter\FilterText;
 use Contributte\Datagrid\Utils\DateTimeHelper;
 use Dibi\Fluent;
-use Dibi\Helpers;
 use Dibi\Result;
 use UnexpectedValueException;
 
@@ -97,31 +95,6 @@ class DibiFluentMssqlDataSource extends DibiFluentDataSource
 				$filter->getColumn(),
 				$valueTo
 			);
-		}
-	}
-
-	protected function applyFilterText(FilterText $filter): void
-	{
-		$condition = $filter->getCondition();
-		$driver = $this->dataSource->getConnection()->getDriver();
-		$or = [];
-
-		foreach ($condition as $column => $value) {
-			$column = Helpers::escape($driver, $column, Fluent::Identifier);
-
-			if ($filter->isExactSearch()) {
-				$this->dataSource->where(sprintf('%s = %%s', $column), $value);
-
-				continue;
-			}
-
-			$or[] = sprintf('%s LIKE "%%%s%%"', $column, $value);
-		}
-
-		if (count($or) > 1) {
-			$this->dataSource->where($filter->hasConjunctionSearch() ? '(%and)' : '(%or)', $or);
-		} else {
-			$this->dataSource->where($or);
 		}
 	}
 


### PR DESCRIPTION
## Summary

Fixes #908

The `DibiFluentMssqlDataSource::applyFilterText()` override was broken in multiple ways:

- **Double N-prefix**: Used `%s` / direct string interpolation in a way that caused `SqlsrvDriver` (Dibi 4.1+) to call `escapeText()` twice, producing `NN'value'` instead of `N'value'`
- **SQL injection**: LIKE search used `sprintf('%s LIKE "%%%s%%"', $column, $value)` — directly interpolating user input into SQL
- **Wrong string delimiters**: Used double quotes (`"..."`) which are identifier delimiters in MSSQL, not string delimiters
- **Missing split-words search**: Ignored `$filter->hasSplitWordsSearch()`

## Fix

Remove the broken override entirely. The base class `DibiFluentDataSource::applyFilterText()` handles all cases correctly via Dibi's `%~like~` modifier, which calls the driver's escape method exactly once (producing correct `N'...'` on MSSQL).