### PR TITLE
Tests: add regression tests for FilterRange with zero value

### DIFF
--- a/tests/Cases/DataSources/ArrayDataSourceTest.phpt
+++ b/tests/Cases/DataSources/ArrayDataSourceTest.phpt
@@ -5,6 +5,7 @@ namespace Contributte\Datagrid\Tests\Cases\DataSources;
 use Contributte\Datagrid\DataSource\ArrayDataSource;
 use Contributte\Datagrid\Filter\FilterDate;
 use Contributte\Datagrid\Filter\FilterDateRange;
+use Contributte\Datagrid\Filter\FilterRange;
 use Contributte\Datagrid\Tests\Files\TestingDatagridFactory;
 use Tester\Assert;
 
@@ -49,6 +50,21 @@ final class ArrayDataSourceTest extends BaseDataSourceTest
 		$ds->filter([$filter]);
 
 		Assert::same(0, $ds->getCount());
+	}
+
+	public function testFilterRangeWithZeroFromValue(): void
+	{
+		$ds = new ArrayDataSource([
+			['id' => 1, 'name' => 'Negative', 'age' => -5, 'address' => ''],
+			['id' => 2, 'name' => 'Zero', 'age' => 0, 'address' => ''],
+			['id' => 3, 'name' => 'Positive', 'age' => 5, 'address' => ''],
+		]);
+
+		$filter = new FilterRange($this->grid, 'a', 'b', 'age', '-');
+		$filter->setValue(['from' => '0', 'to' => '']);
+		$ds->filter([$filter]);
+
+		Assert::same(2, $ds->getCount());
 	}
 
 	public function testFilterDateRangeWithInvalidToValue(): void

--- a/tests/Cases/DataSources/BaseDataSourceTest.phpt
+++ b/tests/Cases/DataSources/BaseDataSourceTest.phpt
@@ -138,6 +138,15 @@ abstract class BaseDataSourceTest extends TestCase
 		], $this->getActualResultAsArray());
 	}
 
+	public function testFilterRangeWithZeroToValue(): void
+	{
+		$filter = new FilterRange($this->grid, 'a', 'b', 'age', '-');
+		$filter->setValue(['from' => '', 'to' => '0']);
+		$this->ds->filter([$filter]);
+
+		Assert::equal([], $this->getActualResultAsArray());
+	}
+
 	public function testFilterOne(): void
 	{
 		$this->ds->filterOne(['id' => 8]);


### PR DESCRIPTION
Closes #730

## Summary

- The bug was already fixed in the codebase (`ArraysHelper::testEmpty` handles `'0'` and all data source `applyFilterRange` implementations use `!== ''` or `is_numeric()`), but no regression tests existed
- Added `testFilterRangeWithZeroToValue` to `BaseDataSourceTest` — runs against all 7 data sources; sets `to = '0'` and expects empty results (all ages in test data are > 0, so if the filter were ignored it would return all 6 records)
- Added `testFilterRangeWithZeroFromValue` to `ArrayDataSourceTest` — uses a custom dataset with negative/zero/positive values; sets `from = '0'` and expects 2 results (age ≥ 0)

## Test plan

- [x] `make tests` passes (29 tests, 0 failures)