### PR TITLE
Add WildCard And Term Query Support for Opensearch- and ElasticSearchDataSource

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
     "nette/tester": "^2.3.4",
     "nextras/dbal": "^4.0 || ^5.0",
     "nextras/orm": "^4.0 || ^5.0",
+    "opensearch-project/opensearch-php": "^2.6",
     "phpstan/phpstan": "^2.1",
     "phpstan/phpstan-deprecation-rules": "^2.0",
     "phpstan/phpstan-mockery": "^2.0",

--- a/src/DataSource/OpenSearchDataSource.php
+++ b/src/DataSource/OpenSearchDataSource.php
@@ -155,7 +155,7 @@ class OpenSearchDataSource extends FilterableDataSource implements IDataSource
 				$options['case_insensitive'] = true;
 			}
 			if ($filter->isExactSearch()) {
-				$this->searchParamsBuilder->addMatchQuery($column, $value, $options);
+				$this->searchParamsBuilder->addMatchQuery($column, $value);
 			} elseif ($filter->isWildCardSearch()) {
 				$this->searchParamsBuilder->addWildCardQuery($column, $value, $options);
 			} elseif ($filter->isTermSearch()) {

--- a/src/DataSource/OpenSearchDataSource.php
+++ b/src/DataSource/OpenSearchDataSource.php
@@ -152,6 +152,12 @@ class OpenSearchDataSource extends FilterableDataSource implements IDataSource
 		foreach ($filter->getCondition() as $column => $value) {
 			if ($filter->isExactSearch()) {
 				$this->searchParamsBuilder->addMatchQuery($column, $value);
+			} elseif ($filter->isWildCardSearch()) {
+				$options = [];
+				if($filter->isCaseInsensitive()) {
+					$options['case_insensitive'] = true;
+				}
+				$this->searchParamsBuilder->addWildCardQuery($column, $value, $options);
 			} else {
 				$this->searchParamsBuilder->addPhrasePrefixQuery($column, $value);
 			}

--- a/src/DataSource/OpenSearchDataSource.php
+++ b/src/DataSource/OpenSearchDataSource.php
@@ -41,7 +41,8 @@ class OpenSearchDataSource extends FilterableDataSource implements IDataSource
 		if (!isset($searchResult['hits'])) {
 			throw new UnexpectedValueException();
 		}
-        $count = $this->client->count($this->searchParamsBuilder->buildParams());
+
+		$count = $this->client->count($this->searchParamsBuilder->buildParams());
 
 		return $count['count'];
 	}
@@ -151,9 +152,10 @@ class OpenSearchDataSource extends FilterableDataSource implements IDataSource
 	{
 		foreach ($filter->getCondition() as $column => $value) {
 			$options = [];
-			if($filter->isCaseInsensitive()) {
+			if ($filter->isCaseInsensitive()) {
 				$options['case_insensitive'] = true;
 			}
+
 			if ($filter->isExactSearch()) {
 				$this->searchParamsBuilder->addMatchQuery($column, $value);
 			} elseif ($filter->isWildCardSearch()) {

--- a/src/DataSource/OpenSearchDataSource.php
+++ b/src/DataSource/OpenSearchDataSource.php
@@ -150,13 +150,13 @@ class OpenSearchDataSource extends FilterableDataSource implements IDataSource
 	public function applyFilterText(FilterText $filter): void
 	{
 		foreach ($filter->getCondition() as $column => $value) {
+			$options = [];
+			if($filter->isCaseInsensitive()) {
+				$options['case_insensitive'] = true;
+			}
 			if ($filter->isExactSearch()) {
-				$this->searchParamsBuilder->addMatchQuery($column, $value);
+				$this->searchParamsBuilder->addMatchQuery($column, $value, $options);
 			} elseif ($filter->isWildCardSearch()) {
-				$options = [];
-				if($filter->isCaseInsensitive()) {
-					$options['case_insensitive'] = true;
-				}
 				$this->searchParamsBuilder->addWildCardQuery($column, $value, $options);
 			} else {
 				$this->searchParamsBuilder->addPhrasePrefixQuery($column, $value);

--- a/src/DataSource/OpenSearchDataSource.php
+++ b/src/DataSource/OpenSearchDataSource.php
@@ -158,6 +158,8 @@ class OpenSearchDataSource extends FilterableDataSource implements IDataSource
 				$this->searchParamsBuilder->addMatchQuery($column, $value, $options);
 			} elseif ($filter->isWildCardSearch()) {
 				$this->searchParamsBuilder->addWildCardQuery($column, $value, $options);
+			} elseif ($filter->isTermSearch()) {
+				$this->searchParamsBuilder->addTermQuery($column, $value, $options);
 			} else {
 				$this->searchParamsBuilder->addPhrasePrefixQuery($column, $value);
 			}

--- a/src/DataSource/OpenSearchDataSource.php
+++ b/src/DataSource/OpenSearchDataSource.php
@@ -1,0 +1,200 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\Datagrid\DataSource;
+
+use Contributte\Datagrid\Exception\DatagridDateTimeHelperException;
+use Contributte\Datagrid\Filter\FilterDate;
+use Contributte\Datagrid\Filter\FilterDateRange;
+use Contributte\Datagrid\Filter\FilterMultiSelect;
+use Contributte\Datagrid\Filter\FilterRange;
+use Contributte\Datagrid\Filter\FilterSelect;
+use Contributte\Datagrid\Filter\FilterText;
+use Contributte\Datagrid\Utils\DateTimeHelper;
+use Contributte\Datagrid\Utils\Sorting;
+use OpenSearch\Client;
+use RuntimeException;
+use UnexpectedValueException;
+
+class OpenSearchDataSource extends FilterableDataSource implements IDataSource
+{
+
+	protected SearchParamsBuilder $searchParamsBuilder;
+
+	/** @var callable */
+	private $rowFactory;
+
+	public function __construct(private Client $client, string $indexName, ?callable $rowFactory = null)
+	{
+		$this->searchParamsBuilder = new SearchParamsBuilder($indexName, true);
+
+		if ($rowFactory === null) {
+			$rowFactory = static fn (array $hit): array => $hit['_source'];
+		}
+
+		$this->rowFactory = $rowFactory;
+	}
+
+	public function getCount(): int
+	{
+		$searchResult = $this->client->search($this->searchParamsBuilder->buildParams());
+
+		if (!isset($searchResult['hits'])) {
+			throw new UnexpectedValueException();
+		}
+        $count = $this->client->count($this->searchParamsBuilder->buildParams());
+
+		return $count['count'];
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getData(): array
+	{
+		$searchResult = $this->client->search($this->searchParamsBuilder->buildParams());
+
+		if (!isset($searchResult['hits'])) {
+			throw new UnexpectedValueException();
+		}
+
+		return array_map($this->rowFactory, $searchResult['hits']['hits']);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function filterOne(array $condition): IDataSource
+	{
+		foreach ($condition as $value) {
+			$this->searchParamsBuilder->addIdsQuery($value);
+		}
+
+		return $this;
+	}
+
+	public function limit(int $offset, int $limit): IDataSource
+	{
+		$this->searchParamsBuilder->setFrom($offset);
+		$this->searchParamsBuilder->setSize($limit);
+
+		return $this;
+	}
+
+	public function applyFilterDate(FilterDate $filter): void
+	{
+		foreach ($filter->getCondition() as $column => $value) {
+			$timestampFrom = null;
+			$timestampTo = null;
+
+			if ($value) {
+				try {
+					$dateFrom = DateTimeHelper::tryConvertToDateTime($value, [$filter->getPhpFormat()]);
+					$dateFrom->setTime(0, 0, 0);
+
+					$timestampFrom = $dateFrom->getTimestamp();
+
+					$dateTo = DateTimeHelper::tryConvertToDateTime($value, [$filter->getPhpFormat()]);
+					$dateTo->setTime(23, 59, 59);
+
+					$timestampTo = $dateTo->getTimestamp();
+
+					$this->searchParamsBuilder->addRangeQuery($column, $timestampFrom, $timestampTo);
+				} catch (DatagridDateTimeHelperException) {
+					// ignore the invalid filter value
+				}
+			}
+		}
+	}
+
+	public function applyFilterDateRange(FilterDateRange $filter): void
+	{
+		foreach ($filter->getCondition() as $column => $values) {
+			$timestampFrom = null;
+			$timestampTo = null;
+
+			if ($values['from']) {
+				try {
+					$dateFrom = DateTimeHelper::tryConvertToDateTime($values['from'], [$filter->getPhpFormat()]);
+					$dateFrom->setTime(0, 0, 0);
+
+					$timestampFrom = $dateFrom->getTimestamp();
+				} catch (DatagridDateTimeHelperException) {
+					// ignore the invalid filter value
+				}
+			}
+
+			if ($values['to']) {
+				try {
+					$dateTo = DateTimeHelper::tryConvertToDateTime($values['to'], [$filter->getPhpFormat()]);
+					$dateTo->setTime(23, 59, 59);
+
+					$timestampTo = $dateTo->getTimestamp();
+				} catch (DatagridDateTimeHelperException) {
+					// ignore the invalid filter value
+				}
+			}
+
+			if (is_int($timestampFrom) || is_int($timestampTo)) {
+				$this->searchParamsBuilder->addRangeQuery($column, $timestampFrom, $timestampTo);
+			}
+		}
+	}
+
+	public function applyFilterRange(FilterRange $filter): void
+	{
+		foreach ($filter->getCondition() as $column => $value) {
+			$this->searchParamsBuilder->addRangeQuery($column, $value['from'] ?? null, $value['to'] ?? null);
+		}
+	}
+
+	public function applyFilterText(FilterText $filter): void
+	{
+		foreach ($filter->getCondition() as $column => $value) {
+			if ($filter->isExactSearch()) {
+				$this->searchParamsBuilder->addMatchQuery($column, $value);
+			} else {
+				$this->searchParamsBuilder->addPhrasePrefixQuery($column, $value);
+			}
+		}
+	}
+
+	public function applyFilterMultiSelect(FilterMultiSelect $filter): void
+	{
+		foreach ($filter->getCondition() as $column => $values) {
+			$this->searchParamsBuilder->addBooleanMatchQuery($column, $values);
+		}
+	}
+
+	public function applyFilterSelect(FilterSelect $filter): void
+	{
+		foreach ($filter->getCondition() as $column => $value) {
+			$this->searchParamsBuilder->addMatchQuery($column, $value);
+		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @throws RuntimeException
+	 */
+	public function sort(Sorting $sorting): IDataSource
+	{
+		if (is_callable($sorting->getSortCallback())) {
+			throw new RuntimeException('No can do - not implemented yet');
+		}
+
+		foreach ($sorting->getSort() as $column => $order) {
+			$this->searchParamsBuilder->setSort(
+				[$column => ['order' => strtolower($order)]]
+			);
+		}
+
+		return $this;
+	}
+
+	public function getDataSource(): SearchParamsBuilder
+	{
+		return $this->searchParamsBuilder;
+	}
+
+}

--- a/src/DataSource/SearchParamsBuilder.php
+++ b/src/DataSource/SearchParamsBuilder.php
@@ -21,7 +21,7 @@ final class SearchParamsBuilder
 
 	private array $idsQueries = [];
 
-	public function __construct(private string $indexName)
+	public function __construct(private string $indexName, private bool $isOpensearch = false)
 	{
 	}
 

--- a/src/DataSource/SearchParamsBuilder.php
+++ b/src/DataSource/SearchParamsBuilder.php
@@ -23,6 +23,8 @@ final class SearchParamsBuilder
 
 	private array $idsQueries = [];
 
+	private array $termQueries = [];
+
 	public function __construct(private string $indexName, private bool $isOpensearch = false)
 	{
 	}
@@ -55,6 +57,10 @@ final class SearchParamsBuilder
 	public function addWildCardQuery(string $field, string $query, array $options = []): void
 	{
 		$this->wildCardQueries[] = [$field => [$query, $options]];
+	}
+	public function addTermQuery(string $field, string $query, array $options = []): void
+	{
+		$this->termQueries[] = [$field => [$query, $options]];
 	}
 
 	public function setSort(array $sort): void
@@ -99,7 +105,8 @@ final class SearchParamsBuilder
 			&& $this->booleanMatchQueries === []
 			&& $this->rangeQueries === []
 			&& $this->idsQueries === []
-		    && $this->wildCardQueries === []) {
+		    && $this->wildCardQueries === []
+			&& $this->termQueries === [] ) {
 			return $return;
 		}
 
@@ -123,6 +130,16 @@ final class SearchParamsBuilder
 
 		foreach ($this->matchQueries as $matchQuery) {
 			foreach ($matchQuery as $field => [$query, $options]) {
+				$return['body']['query']['bool']['must'][] = [
+					'match' => [
+						$field => ['query' => $query],
+					],
+				];
+			}
+		}
+
+		foreach ($this->termQueries as $matchQuery) {
+			foreach ($matchQuery as $field => [$query, $options]) {
 				$fieldQueryParams = [
 					'query' => $query
 				];
@@ -130,7 +147,7 @@ final class SearchParamsBuilder
 					$fieldQueryParams = array_merge($fieldQueryParams, $options);
 				}
 				$return['body']['query']['bool']['must'][] = [
-					'match' => [
+					'term' => [
 						$field => $fieldQueryParams,
 					],
 				];

--- a/src/DataSource/SearchParamsBuilder.php
+++ b/src/DataSource/SearchParamsBuilder.php
@@ -34,9 +34,9 @@ final class SearchParamsBuilder
 		$this->phrasePrefixQueries[] = [$field => $query];
 	}
 
-	public function addMatchQuery(string $field, mixed $query, array $options = []): void
+	public function addMatchQuery(string $field, mixed $query): void
 	{
-		$this->matchQueries[] = [$field => [$query, $options]];
+		$this->matchQueries[] = [$field => $query ];
 	}
 
 	public function addBooleanMatchQuery(string $field, array $queries): void
@@ -129,7 +129,7 @@ final class SearchParamsBuilder
 		}
 
 		foreach ($this->matchQueries as $matchQuery) {
-			foreach ($matchQuery as $field => [$query, $options]) {
+			foreach ($matchQuery as $field => $query) {
 				$return['body']['query']['bool']['must'][] = [
 					'match' => [
 						$field => ['query' => $query],
@@ -141,7 +141,7 @@ final class SearchParamsBuilder
 		foreach ($this->termQueries as $matchQuery) {
 			foreach ($matchQuery as $field => [$query, $options]) {
 				$fieldQueryParams = [
-					'query' => $query
+					'value' => $query
 				];
 				if ($this->isOpensearch && count($options) > 0) {
 					$fieldQueryParams = array_merge($fieldQueryParams, $options);

--- a/src/DataSource/SearchParamsBuilder.php
+++ b/src/DataSource/SearchParamsBuilder.php
@@ -36,7 +36,7 @@ final class SearchParamsBuilder
 
 	public function addMatchQuery(string $field, mixed $query): void
 	{
-		$this->matchQueries[] = [$field => $query ];
+		$this->matchQueries[] = [$field => $query];
 	}
 
 	public function addBooleanMatchQuery(string $field, array $queries): void
@@ -58,6 +58,7 @@ final class SearchParamsBuilder
 	{
 		$this->wildCardQueries[] = [$field => [$query, $options]];
 	}
+
 	public function addTermQuery(string $field, string $query, array $options = []): void
 	{
 		$this->termQueries[] = [$field => [$query, $options]];
@@ -105,8 +106,8 @@ final class SearchParamsBuilder
 			&& $this->booleanMatchQueries === []
 			&& $this->rangeQueries === []
 			&& $this->idsQueries === []
-		    && $this->wildCardQueries === []
-			&& $this->termQueries === [] ) {
+			&& $this->wildCardQueries === []
+			&& $this->termQueries === []) {
 			return $return;
 		}
 
@@ -141,11 +142,12 @@ final class SearchParamsBuilder
 		foreach ($this->termQueries as $matchQuery) {
 			foreach ($matchQuery as $field => [$query, $options]) {
 				$fieldQueryParams = [
-					'value' => $query
+					'value' => $query,
 				];
 				if ($this->isOpensearch && count($options) > 0) {
 					$fieldQueryParams = array_merge($fieldQueryParams, $options);
 				}
+
 				$return['body']['query']['bool']['must'][] = [
 					'term' => [
 						$field => $fieldQueryParams,
@@ -156,15 +158,17 @@ final class SearchParamsBuilder
 
 		foreach ($this->wildCardQueries as $wildCardQuery) {
 			foreach ($wildCardQuery as $field => [$query, $options]) {
-				if(!(str_contains($query, '*') || str_contains($query, '?'))) {
+				if (!(str_contains($query, '*') || str_contains($query, '?'))) {
 					$query .= '*';
 				}
+
 				$fieldQueryParams = [
-					'value' => $query
+					'value' => $query,
 				];
 				if (count($options) > 0) {
 					$fieldQueryParams = array_merge($fieldQueryParams, $options);
 				}
+
 				$return['body']['query']['bool']['must'][] = [
 					'wildcard' => [
 						$field => $fieldQueryParams,

--- a/src/DataSource/SearchParamsBuilder.php
+++ b/src/DataSource/SearchParamsBuilder.php
@@ -13,6 +13,8 @@ final class SearchParamsBuilder
 
 	private array $phrasePrefixQueries = [];
 
+	private array $wildCardQueries = [];
+
 	private array $matchQueries = [];
 
 	private array $booleanMatchQueries = [];
@@ -48,6 +50,11 @@ final class SearchParamsBuilder
 	public function addIdsQuery(array $ids): void
 	{
 		$this->idsQueries[] = $ids;
+	}
+
+	public function addWildCardQuery(string $field, string $query, array $options): void
+	{
+		$this->wildCardQueries[] = [$field => [$query, $options]];
 	}
 
 	public function setSort(array $sort): void
@@ -120,6 +127,26 @@ final class SearchParamsBuilder
 						$field => [
 							'query' => $query,
 						],
+					],
+				];
+			}
+		}
+
+		foreach ($this->wildCardQueries as $wildCardQuery) {
+			foreach ($wildCardQuery as $field => [$query, $options]) {
+
+				$fieldConfig = [
+					'value' => $query
+				];
+				if(!(str_contains($query, '*') || str_contains($query, '?'))) {
+					$query .= '*';
+				}
+				if ($this->isOpensearch && !empty($options)) {
+					$fieldConfig = array_merge($fieldConfig, $options);
+				}
+				$return['body']['query']['bool']['must'][] = [
+					'wildcard' => [
+						$field => $fieldConfig,
 					],
 				];
 			}

--- a/src/DataSource/SearchParamsBuilder.php
+++ b/src/DataSource/SearchParamsBuilder.php
@@ -32,9 +32,9 @@ final class SearchParamsBuilder
 		$this->phrasePrefixQueries[] = [$field => $query];
 	}
 
-	public function addMatchQuery(string $field, mixed $query): void
+	public function addMatchQuery(string $field, mixed $query, array $options = []): void
 	{
-		$this->matchQueries[] = [$field => $query];
+		$this->matchQueries[] = [$field => [$query, $options]];
 	}
 
 	public function addBooleanMatchQuery(string $field, array $queries): void
@@ -52,7 +52,7 @@ final class SearchParamsBuilder
 		$this->idsQueries[] = $ids;
 	}
 
-	public function addWildCardQuery(string $field, string $query, array $options): void
+	public function addWildCardQuery(string $field, string $query, array $options = []): void
 	{
 		$this->wildCardQueries[] = [$field => [$query, $options]];
 	}
@@ -98,7 +98,8 @@ final class SearchParamsBuilder
 			&& $this->matchQueries === []
 			&& $this->booleanMatchQueries === []
 			&& $this->rangeQueries === []
-			&& $this->idsQueries === []) {
+			&& $this->idsQueries === []
+		    && $this->wildCardQueries === []) {
 			return $return;
 		}
 
@@ -121,12 +122,16 @@ final class SearchParamsBuilder
 		}
 
 		foreach ($this->matchQueries as $matchQuery) {
-			foreach ($matchQuery as $field => $query) {
+			foreach ($matchQuery as $field => [$query, $options]) {
+				$fieldQueryParams = [
+					'query' => $query
+				];
+				if ($this->isOpensearch && count($options) > 0) {
+					$fieldQueryParams = array_merge($fieldQueryParams, $options);
+				}
 				$return['body']['query']['bool']['must'][] = [
 					'match' => [
-						$field => [
-							'query' => $query,
-						],
+						$field => $fieldQueryParams,
 					],
 				];
 			}
@@ -134,19 +139,18 @@ final class SearchParamsBuilder
 
 		foreach ($this->wildCardQueries as $wildCardQuery) {
 			foreach ($wildCardQuery as $field => [$query, $options]) {
-
-				$fieldConfig = [
-					'value' => $query
-				];
 				if(!(str_contains($query, '*') || str_contains($query, '?'))) {
 					$query .= '*';
 				}
-				if ($this->isOpensearch && !empty($options)) {
-					$fieldConfig = array_merge($fieldConfig, $options);
+				$fieldQueryParams = [
+					'value' => $query
+				];
+				if (count($options) > 0) {
+					$fieldQueryParams = array_merge($fieldQueryParams, $options);
 				}
 				$return['body']['query']['bool']['must'][] = [
 					'wildcard' => [
-						$field => $fieldConfig,
+						$field => $fieldQueryParams,
 					],
 				];
 			}

--- a/src/Filter/FilterText.php
+++ b/src/Filter/FilterText.php
@@ -18,6 +18,8 @@ class FilterText extends Filter
 
 	protected bool $caseInsensitive = false;
 
+	protected bool $term = false;
+
 	protected bool $splitWordsSearch = true;
 
 	protected bool $conjunctionSearch = false;
@@ -122,5 +124,18 @@ class FilterText extends Filter
 	{
 		return $this->caseInsensitive;
 	}
+
+	public function setTermSearch(bool $term = true): self
+	{
+		$this->term = $term;
+		return $this;
+	}
+
+	public function isTermSearch(): bool
+	{
+		return $this->term;
+	}
+
+
 
 }

--- a/src/Filter/FilterText.php
+++ b/src/Filter/FilterText.php
@@ -14,6 +14,10 @@ class FilterText extends Filter
 
 	protected bool $exact = false;
 
+	protected bool $wildCard = false;
+
+	protected bool $caseInsensitive = false;
+
 	protected bool $splitWordsSearch = true;
 
 	protected bool $conjunctionSearch = false;
@@ -94,6 +98,29 @@ class FilterText extends Filter
 	public function hasConjunctionSearch(): bool
 	{
 		return $this->conjunctionSearch;
+	}
+
+	public function setWildCard(bool $wildCard = true): self
+	{
+		$this->wildCard = $wildCard;
+
+		return $this;
+	}
+
+	public function isWildCardSearch(): bool
+	{
+		return $this->wildCard;
+	}
+
+	public function setCaseInsensitive(bool $caseInsensitive = true): self
+	{
+		$this->caseInsensitive = $caseInsensitive;
+		return $this;
+	}
+
+	public function isCaseInsensitive(): bool
+	{
+		return $this->caseInsensitive;
 	}
 
 }

--- a/src/Filter/FilterText.php
+++ b/src/Filter/FilterText.php
@@ -117,6 +117,7 @@ class FilterText extends Filter
 	public function setCaseInsensitive(bool $caseInsensitive = true): self
 	{
 		$this->caseInsensitive = $caseInsensitive;
+
 		return $this;
 	}
 
@@ -128,6 +129,7 @@ class FilterText extends Filter
 	public function setTermSearch(bool $term = true): self
 	{
 		$this->term = $term;
+
 		return $this;
 	}
 
@@ -135,7 +137,5 @@ class FilterText extends Filter
 	{
 		return $this->term;
 	}
-
-
 
 }

--- a/tests/Cases/DataSources/SearchParamsBuilderTest.phpt
+++ b/tests/Cases/DataSources/SearchParamsBuilderTest.phpt
@@ -280,113 +280,114 @@ final class SearchParamsBuilderTest extends TestCase
 	}
 
 	public function testWildCardQuery(): void
-    {
-    		$this->searchParamsBuilder->addWildCardQuery('name', 'john');
+	{
+			$this->searchParamsBuilder->addWildCardQuery('name', 'john');
 
-    		Assert::same(
-    			[
-    				'index' => 'users',
-    				'body' => [
-    					'query' => [
-    						'bool' => [
-    							'must' => [
-    								[
-    									'wildcard' => [
-    										'name' => [
-    											'value' => 'john*',
-    										],
-    									],
-    								],
-    							],
-    						],
-    					],
-    				],
-    			],
-    			$this->searchParamsBuilder->buildParams()
-    		);
-    }
+			Assert::same(
+				[
+					'index' => 'users',
+					'body' => [
+						'query' => [
+							'bool' => [
+								'must' => [
+									[
+										'wildcard' => [
+											'name' => [
+												'value' => 'john*',
+											],
+										],
+									],
+								],
+							],
+						],
+					],
+				],
+				$this->searchParamsBuilder->buildParams()
+			);
+	}
 
 	public function testWildCardQuery2(): void
-    {
-    		$this->searchParamsBuilder->addWildCardQuery('name', 'j?hn');
+	{
+			$this->searchParamsBuilder->addWildCardQuery('name', 'j?hn');
 
-    		Assert::same(
-    			[
-    				'index' => 'users',
-    				'body' => [
-    					'query' => [
-    						'bool' => [
-    							'must' => [
-    								[
-    									'wildcard' => [
-    										'name' => [
-    											'value' => 'j?hn',
-    										],
-    									],
-    								],
-    							],
-    						],
-    					],
-    				],
-    			],
-    			$this->searchParamsBuilder->buildParams()
-    		);
-    }
+			Assert::same(
+				[
+					'index' => 'users',
+					'body' => [
+						'query' => [
+							'bool' => [
+								'must' => [
+									[
+										'wildcard' => [
+											'name' => [
+												'value' => 'j?hn',
+											],
+										],
+									],
+								],
+							],
+						],
+					],
+				],
+				$this->searchParamsBuilder->buildParams()
+			);
+	}
 
 	public function testWildCardQuery3(): void
-    {
-    		$this->searchParamsBuilder->addWildCardQuery('name', '*john');
+	{
+			$this->searchParamsBuilder->addWildCardQuery('name', '*john');
 
-    		Assert::same(
-    			[
-    				'index' => 'users',
-    				'body' => [
-    					'query' => [
-    						'bool' => [
-    							'must' => [
-    								[
-    									'wildcard' => [
-    										'name' => [
-    											'value' => '*john',
-    										],
-    									],
-    								],
-    							],
-    						],
-    					],
-    				],
-    			],
-    			$this->searchParamsBuilder->buildParams()
-    		);
-    }
+			Assert::same(
+				[
+					'index' => 'users',
+					'body' => [
+						'query' => [
+							'bool' => [
+								'must' => [
+									[
+										'wildcard' => [
+											'name' => [
+												'value' => '*john',
+											],
+										],
+									],
+								],
+							],
+						],
+					],
+				],
+				$this->searchParamsBuilder->buildParams()
+			);
+	}
 
 	public function testWildCardQueryCaseInsensitive(): void
-    {
-    		$this->searchParamsBuilder->addWildCardQuery('name', 'john', ['case_insensitive' => true]);
+	{
+			$this->searchParamsBuilder->addWildCardQuery('name', 'john', ['case_insensitive' => true]);
 
-    		Assert::same(
-    			[
-    				'index' => 'users',
-    				'body' => [
-    					'query' => [
-    						'bool' => [
-    							'must' => [
-    								[
-    									'wildcard' => [
-    										'name' => [
-    											'value' => 'john*',
-    											'case_insensitive' => true
-    										],
-    									],
-    								],
-    							],
-    						],
-    					],
-    				],
-    			],
-    			$this->searchParamsBuilder->buildParams()
-    		);
-    }
+			Assert::same(
+				[
+					'index' => 'users',
+					'body' => [
+						'query' => [
+							'bool' => [
+								'must' => [
+									[
+										'wildcard' => [
+											'name' => [
+												'value' => 'john*',
+												'case_insensitive' => true,
+											],
+										],
+									],
+								],
+							],
+						],
+					],
+				],
+				$this->searchParamsBuilder->buildParams()
+			);
+	}
+
 	public function testAllTogetherWithWildCardAndTermSearch(): void
 	{
 		$this->searchParamsBuilder->setSort(['name' => ['order' => 'desc']]);
@@ -421,16 +422,16 @@ final class SearchParamsBuilderTest extends TestCase
 									'match' => ['name' => ['query' => 'john']],
 								],
 
-                                [
-                                	'term' => [
-                                			'name' => [
-                                				'value' => 'john',
-                                			],
-                                	],
-                                ],
-                                [
-                                    'wildcard' => ['name' => ['value' => 'john*', 'case_insensitive' => true]],
-                                ],
+								[
+									'term' => [
+											'name' => [
+												'value' => 'john',
+											],
+									],
+								],
+								[
+									'wildcard' => ['name' => ['value' => 'john*', 'case_insensitive' => true]],
+								],
 								[
 									'bool' => [
 										'should' => [
@@ -461,6 +462,7 @@ final class SearchParamsBuilderTest extends TestCase
 			$this->searchParamsBuilder->buildParams()
 		);
 	}
+
 	public function testTermQueryOpenSearch(): void
 	{
 		$searchBuilder = new SearchParamsBuilder('users', true);
@@ -477,7 +479,7 @@ final class SearchParamsBuilderTest extends TestCase
 									'term' => [
 										'name' => [
 											'value' => 'john',
-											'case_insensitive' => true
+											'case_insensitive' => true,
 										],
 									],
 								],
@@ -489,6 +491,7 @@ final class SearchParamsBuilderTest extends TestCase
 			$searchBuilder->buildParams()
 		);
 	}
+
 	public function testTermQueryElasticSearch(): void
 	{
 		$this->searchParamsBuilder->addTermQuery('name', 'john', ['case_insensitive' => true]);

--- a/tests/Cases/DataSources/SearchParamsBuilderTest.phpt
+++ b/tests/Cases/DataSources/SearchParamsBuilderTest.phpt
@@ -15,7 +15,7 @@ final class SearchParamsBuilderTest extends TestCase
 
 	public function setUp(): void
 	{
-		$this->searchParamsBuilder = new SearchParamsBuilder('users', 'user');
+		$this->searchParamsBuilder = new SearchParamsBuilder('users');
 	}
 
 	public function testEmptyQuery(): void
@@ -268,6 +268,234 @@ final class SearchParamsBuilderTest extends TestCase
 								[
 									'ids' => [
 										'values' => [0, 1, 1, 2, 3, 5, 8],
+									],
+								],
+							],
+						],
+					],
+				],
+			],
+			$this->searchParamsBuilder->buildParams()
+		);
+	}
+
+	public function testWildCardQuery(): void
+    {
+    		$this->searchParamsBuilder->addWildCardQuery('name', 'john');
+
+    		Assert::same(
+    			[
+    				'index' => 'users',
+    				'body' => [
+    					'query' => [
+    						'bool' => [
+    							'must' => [
+    								[
+    									'wildcard' => [
+    										'name' => [
+    											'value' => 'john*',
+    										],
+    									],
+    								],
+    							],
+    						],
+    					],
+    				],
+    			],
+    			$this->searchParamsBuilder->buildParams()
+    		);
+    }
+
+	public function testWildCardQuery2(): void
+    {
+    		$this->searchParamsBuilder->addWildCardQuery('name', 'j?hn');
+
+    		Assert::same(
+    			[
+    				'index' => 'users',
+    				'body' => [
+    					'query' => [
+    						'bool' => [
+    							'must' => [
+    								[
+    									'wildcard' => [
+    										'name' => [
+    											'value' => 'j?hn',
+    										],
+    									],
+    								],
+    							],
+    						],
+    					],
+    				],
+    			],
+    			$this->searchParamsBuilder->buildParams()
+    		);
+    }
+
+	public function testWildCardQuery3(): void
+    {
+    		$this->searchParamsBuilder->addWildCardQuery('name', '*john');
+
+    		Assert::same(
+    			[
+    				'index' => 'users',
+    				'body' => [
+    					'query' => [
+    						'bool' => [
+    							'must' => [
+    								[
+    									'wildcard' => [
+    										'name' => [
+    											'value' => '*john',
+    										],
+    									],
+    								],
+    							],
+    						],
+    					],
+    				],
+    			],
+    			$this->searchParamsBuilder->buildParams()
+    		);
+    }
+
+	public function testWildCardQueryCaseInsensitive(): void
+    {
+    		$this->searchParamsBuilder->addWildCardQuery('name', 'john', ['case_insensitive' => true]);
+
+    		Assert::same(
+    			[
+    				'index' => 'users',
+    				'body' => [
+    					'query' => [
+    						'bool' => [
+    							'must' => [
+    								[
+    									'wildcard' => [
+    										'name' => [
+    											'value' => 'john*',
+    											'case_insensitive' => true
+    										],
+    									],
+    								],
+    							],
+    						],
+    					],
+    				],
+    			],
+    			$this->searchParamsBuilder->buildParams()
+    		);
+    }
+	public function testAllTogetherWithWildCard(): void
+	{
+		$this->searchParamsBuilder->setSort(['name' => ['order' => 'desc']]);
+		$this->searchParamsBuilder->setFrom(0);
+		$this->searchParamsBuilder->setSize(20);
+		$this->searchParamsBuilder->addPhrasePrefixQuery('name', 'john');
+		$this->searchParamsBuilder->addMatchQuery('name', 'john');
+		$this->searchParamsBuilder->addBooleanMatchQuery('status', ['active', 'disabled']);
+		$this->searchParamsBuilder->addRangeQuery('score', 8, 64);
+		$this->searchParamsBuilder->addIdsQuery([0, 1, 1, 2, 3, 5, 8]);
+		$this->searchParamsBuilder->addWildCardQuery('name', 'john', ['case_insensitive' => true]);
+
+		Assert::same(
+			[
+				'index' => 'users',
+				'body' => [
+					'sort' => ['name' => ['order' => 'desc']],
+					'from' => 0,
+					'size' => 20,
+					'query' => [
+						'bool' => [
+							'must' => [
+								[
+									'multi_match' => [
+										'query' => 'john',
+										'type' => 'phrase_prefix',
+										'fields' => ['name'],
+									],
+								],
+								[
+									'match' => ['name' => ['query' => 'john']],
+								],
+								[
+                                	'wildcard' => ['name' => ['value' => 'john*', 'case_insensitive' => true]],
+                                ],
+								[
+									'bool' => [
+										'should' => [
+											[
+												[
+													'match' => ['status' => ['query' => 'active']],
+												],
+												[
+													'match' => ['status' => ['query' => 'disabled']],
+												],
+											],
+										],
+									],
+								],
+								[
+									'range' => ['score' => ['gte' => 8, 'lte' => 64]],
+								],
+								[
+									'ids' => [
+										'values' => [0, 1, 1, 2, 3, 5, 8],
+									],
+								],
+							],
+						],
+					],
+				],
+			],
+			$this->searchParamsBuilder->buildParams()
+		);
+	}
+	public function testMatchQueryOpenSearch(): void
+	{
+		$searchBuilder = new SearchParamsBuilder('users', true);
+		$searchBuilder->addMatchQuery('name', 'john', ['case_insensitive' => true]);
+
+		Assert::same(
+			[
+				'index' => 'users',
+				'body' => [
+					'query' => [
+						'bool' => [
+							'must' => [
+								[
+									'match' => [
+										'name' => [
+											'query' => 'john',
+											'case_insensitive' => true
+										],
+									],
+								],
+							],
+						],
+					],
+				],
+			],
+			$searchBuilder->buildParams()
+		);
+	}
+	public function testMatchQueryElasticSearch(): void
+	{
+		$this->searchParamsBuilder->addMatchQuery('name', 'john', ['case_insensitive' => true]);
+
+		Assert::same(
+			[
+				'index' => 'users',
+				'body' => [
+					'query' => [
+						'bool' => [
+							'must' => [
+								[
+									'match' => [
+										'name' => [
+											'query' => 'john',
+										],
 									],
 								],
 							],

--- a/tests/Cases/DataSources/SearchParamsBuilderTest.phpt
+++ b/tests/Cases/DataSources/SearchParamsBuilderTest.phpt
@@ -387,7 +387,7 @@ final class SearchParamsBuilderTest extends TestCase
     			$this->searchParamsBuilder->buildParams()
     		);
     }
-	public function testAllTogetherWithWildCard(): void
+	public function testAllTogetherWithWildCardAndTermSearch(): void
 	{
 		$this->searchParamsBuilder->setSort(['name' => ['order' => 'desc']]);
 		$this->searchParamsBuilder->setFrom(0);
@@ -398,6 +398,7 @@ final class SearchParamsBuilderTest extends TestCase
 		$this->searchParamsBuilder->addRangeQuery('score', 8, 64);
 		$this->searchParamsBuilder->addIdsQuery([0, 1, 1, 2, 3, 5, 8]);
 		$this->searchParamsBuilder->addWildCardQuery('name', 'john', ['case_insensitive' => true]);
+		$this->searchParamsBuilder->addTermQuery('name', 'john', ['case_insensitive' => true]);
 
 		Assert::same(
 			[
@@ -419,8 +420,16 @@ final class SearchParamsBuilderTest extends TestCase
 								[
 									'match' => ['name' => ['query' => 'john']],
 								],
-								[
-                                	'wildcard' => ['name' => ['value' => 'john*', 'case_insensitive' => true]],
+
+                                [
+                                	'term' => [
+                                			'name' => [
+                                				'query' => 'john',
+                                			],
+                                	],
+                                ],
+                                [
+                                    'wildcard' => ['name' => ['value' => 'john*', 'case_insensitive' => true]],
                                 ],
 								[
 									'bool' => [
@@ -452,10 +461,10 @@ final class SearchParamsBuilderTest extends TestCase
 			$this->searchParamsBuilder->buildParams()
 		);
 	}
-	public function testMatchQueryOpenSearch(): void
+	public function testTermQueryOpenSearch(): void
 	{
 		$searchBuilder = new SearchParamsBuilder('users', true);
-		$searchBuilder->addMatchQuery('name', 'john', ['case_insensitive' => true]);
+		$searchBuilder->addTermQuery('name', 'john', ['case_insensitive' => true]);
 
 		Assert::same(
 			[
@@ -465,7 +474,7 @@ final class SearchParamsBuilderTest extends TestCase
 						'bool' => [
 							'must' => [
 								[
-									'match' => [
+									'term' => [
 										'name' => [
 											'query' => 'john',
 											'case_insensitive' => true
@@ -480,9 +489,9 @@ final class SearchParamsBuilderTest extends TestCase
 			$searchBuilder->buildParams()
 		);
 	}
-	public function testMatchQueryElasticSearch(): void
+	public function testTermQueryElasticSearch(): void
 	{
-		$this->searchParamsBuilder->addMatchQuery('name', 'john', ['case_insensitive' => true]);
+		$this->searchParamsBuilder->addTermQuery('name', 'john', ['case_insensitive' => true]);
 
 		Assert::same(
 			[
@@ -492,7 +501,7 @@ final class SearchParamsBuilderTest extends TestCase
 						'bool' => [
 							'must' => [
 								[
-									'match' => [
+									'term' => [
 										'name' => [
 											'query' => 'john',
 										],

--- a/tests/Cases/DataSources/SearchParamsBuilderTest.phpt
+++ b/tests/Cases/DataSources/SearchParamsBuilderTest.phpt
@@ -424,7 +424,7 @@ final class SearchParamsBuilderTest extends TestCase
                                 [
                                 	'term' => [
                                 			'name' => [
-                                				'query' => 'john',
+                                				'value' => 'john',
                                 			],
                                 	],
                                 ],
@@ -476,7 +476,7 @@ final class SearchParamsBuilderTest extends TestCase
 								[
 									'term' => [
 										'name' => [
-											'query' => 'john',
+											'value' => 'john',
 											'case_insensitive' => true
 										],
 									],
@@ -503,7 +503,7 @@ final class SearchParamsBuilderTest extends TestCase
 								[
 									'term' => [
 										'name' => [
-											'query' => 'john',
+											'value' => 'john',
 										],
 									],
 								],


### PR DESCRIPTION
Adds a DataSource for OpenSearch.
For Elasticsearch and OpenSearch, both wildcard and term search methods will be added.
For OpenSearch, it will be possible to use case_insensitive in term searches.