### PR TITLE
Fix: enable clear_button plugin for TomSelect

### DIFF
--- a/assets/datagrid-full.ts
+++ b/assets/datagrid-full.ts
@@ -45,7 +45,10 @@ document.addEventListener("DOMContentLoaded", () => {
 				new NetteFormsPlugin(netteForms),
 				new SortablePlugin(new SortableJS()),
 				new DatepickerPlugin(new VanillaDatepicker({ buttonClass: 'btn' })),
-				new SelectpickerPlugin(new TomSelect(Select)),
+				new SelectpickerPlugin(new TomSelect(Select, {
+					plugins: ['clear_button'],
+					maxOptions: null,
+				})),
 				new TreeViewPlugin(),
 			],
 		},


### PR DESCRIPTION
## Summary
- Enable `clear_button` plugin for TomSelect so users can clear a selected filter value without resetting all filters
- Set `maxOptions: null` to remove the default limit on visible options

Closes #1279