### PR TITLE
Fix: FilterSelect implicit validation breaks form on hidden column (#1281)

### DIFF
--- a/src/Filter/FilterSelect.php
+++ b/src/Filter/FilterSelect.php
@@ -104,6 +104,13 @@ class FilterSelect extends OneColumnFilter
 	{
 		$input = $container->addSelect($key, $name, $options);
 
+		// SelectBox adds an implicit "Filled" rule when no prompt is set.
+		// A filter is never required, and when its column is hidden the input
+		// isn't rendered, so nothing is submitted and the rule fails — which
+		// invalidates the whole filter container and triggers a warning on
+		// getValues(). Filters don't need validation, so drop it here.
+		$input->getRules()->reset();
+
 		if ($this->getPrompt() !== null) {
 			$input->setPrompt($this->getPrompt());
 		}

--- a/tests/Cases/FilterTest.phpt
+++ b/tests/Cases/FilterTest.phpt
@@ -110,6 +110,40 @@ final class FilterTest extends TestCase
 		Assert::count(0, $grid->filter);
 	}
 
+	/**
+	 * Regression test for https://github.com/contributte/datagrid/issues/1281
+	 *
+	 * A FilterSelect on a hidden column isn't rendered in HTML, so no value is
+	 * submitted for it. SelectBox's constructor adds an implicit "Filled" rule
+	 * when no prompt is set, which used to fail validation for the missing
+	 * value, invalidate the filter container, and trigger an E_USER_WARNING
+	 * from Container::getValues() in Datagrid::filterSucceeded().
+	 */
+	public function testFilterSelectHasNoImplicitValidation(): void
+	{
+		$factory = new TestingDatagridFactoryRouter();
+		/** @var Datagrid $grid */
+		$grid = $factory->createTestingDatagrid()->getComponent('grid');
+
+		$grid->addColumnText('name', 'Name')
+			->setFilterText();
+
+		$grid->addColumnText('status', 'Status')
+			->setFilterSelect(['yes' => 'Yes', 'no' => 'No']);
+
+		$filterForm = $grid->createComponentFilter();
+
+		$filterContainer = $filterForm->getComponent('filter');
+		Assert::type(Container::class, $filterContainer);
+
+		$filterContainer->validate();
+
+		// With no value set (as if the select was hidden and not submitted),
+		// the container must still be valid — no implicit Filled rule should
+		// fire on the FilterSelect.
+		Assert::true($filterContainer->isValid());
+	}
+
 }
 
 (new FilterTest())->run();


### PR DESCRIPTION
## Summary

Fixes #1281.

`Nette\Forms\Controls\SelectBox` constructor adds an implicit `Filled` validation rule when no prompt is set. For a `FilterSelect` on a column that's hidden via `setDefaultHide()` or `handleHideColumn`, the input isn't rendered, so nothing is submitted for it. The rule then fails, the filter container becomes invalid, and `Container::getValues()` in `Datagrid::filterSucceeded()` triggers:

> `Nette\Forms\Container::getValues() invoked but the form is not valid (form 'filter').`

Filters are search inputs, not required data entry, so this PR resets the rules on the underlying `SelectBox` in `FilterSelect::addControl()`. The fix is inherited by `FilterMultiSelect` (no-op there since `addMultiSelect` doesn't add implicit validation).

## Test plan

- [x] Added regression test `testFilterSelectHasNoImplicitValidation` in `tests/Cases/FilterTest.phpt` — verified it fails before the fix and passes after.
- [x] `make tests` — 29 passed, 1 skipped (MySQL not running).
- [x] `make phpstan` — clean.
- [x] `make cs` — clean.

@jaroslavlibal could you give this branch a try in your project and confirm the warning is gone? 🙏