### PR TITLE
Fix: autosubmit dropped when modifier keyup follows a character keyup

### DIFF
--- a/assets/plugins/features/autosubmit.ts
+++ b/assets/plugins/features/autosubmit.ts
@@ -66,17 +66,20 @@ export class AutosubmitPlugin implements DatagridPlugin {
 						);
 					}
 
-					submitEl.addEventListener(
-						"keyup",
-						debounce(e => {
-							// Ignore keys such as alt, ctrl, etc, F-keys... (when enter is not pressed)
-							if (!isEnter(e) && (isInKeyRange(e, 9, 40) || isFunctionKey(e))) {
-								return;
-							}
-
-							return datagrid.ajax.submitForm(form);
-						})
-					);
+					const debouncedSubmit = debounce(() => datagrid.ajax.submitForm(form));
+					submitEl.addEventListener("keyup", (e) => {
+						// Enter submits immediately, no debounce wait.
+						if (isEnter(e)) {
+							datagrid.ajax.submitForm(form);
+							return;
+						}
+						// Skip alt/ctrl/etc and F-keys here, not inside debounce — a late
+						// modifier keyup would otherwise overwrite the debounced submit's target.
+						if (isInKeyRange(e, 9, 40) || isFunctionKey(e)) {
+							return;
+						}
+						debouncedSubmit();
+					});
 				}
 			});
 	}

--- a/assets/utils.ts
+++ b/assets/utils.ts
@@ -7,8 +7,8 @@ export function isPromise<T = any>(p: any): p is Promise<T> {
 
 export function isInKeyRange(e: KeyboardEvent, min: number, max: number): boolean {
 	if (e.key.length !== 1) { // Named keys (Tab, Shift, ArrowLeft, etc.) are always considered in range
-		if (e.key === 'Backspace' || e.key === 'Delete') {
-			return false; // Editing keys change the input value and should still trigger autosubmit
+		if (e.key === 'Backspace' || e.key === 'Delete' || e.key === 'Unidentified') {
+			return false; // Editing keys (and the virtual-keyboard placeholder) change the input value and should still trigger autosubmit
 		}
 		return true;
 	}


### PR DESCRIPTION
 ## Problem

After typing into a `data-autosubmit` filter input, running `Ctrl+A` → `Ctrl+X` (releasing `Ctrl` between) leaves the grid filtered to the old value — `submitForm` never fires on the now-empty input. `Ctrl+V` afterwards puts pasted text in the input but the filter still doesn't re-run. Holding `Ctrl` down throughout avoids it.

  ## Cause

Each shortcut ends with a `Control` keyup right after the character keyup. The skip-keys predicate sits inside the `debounce()` wrapper, so the debounce keeps resetting and ends up firing for the `Control` event. `isInKeyRange` returns `true` for multi-char named keys after ae9e9be / c9835f1, the handler early-returns and `submitForm` never runs. Same shape also affects `Tab` and Arrow keys arriving after a character keyup.

  ## Fix

Move the skip predicate out of `debounce()`, into the listener. Modifier and nav keyups no longer reset the debounce timer, so the pending character keyup's submit fires as intended. `isInKeyRange` itself is untouched.

  Also bind Enter to immediate submit, no debounce wait.

  ## Verification

Live-tested in our project with browser-side keyup instrumentation. With the fix the debounce stays anchored to the character keyup and `submitForm` runs.

  ---

¹ The skeleton demo at <https://examples.contributte.org/datagrid-skeleton/filters/> doesn't reproduce the bug only because its deployed `composer.lock` pins `ublaboo/datagrid` to `dev-master @ bf8b0e0` (pre-regression), even though `composer.json` is `^7.2`. Fresh `composer install` of the skeleton today resolves to `v7.2.0` and reproduces.

² Side note: `package.json`'s `version` field is `7.1.0` on the `v7.2.0` tag (and `6.9.2` on `v7.0.0`). Looks like releases don't bump it.