### PR TITLE
Fix: PHPStan errors in Datagrid and Filter classes

### DIFF
--- a/src/Datagrid.php
+++ b/src/Datagrid.php
@@ -47,7 +47,6 @@ use DateTime;
 use InvalidArgumentException;
 use Nette\Application\Attributes\Persistent;
 use Nette\Application\ForbiddenRequestException;
-use Nette\Application\IPresenter;
 use Nette\Application\Request;
 use Nette\Application\UI\Component;
 use Nette\Application\UI\Control;
@@ -2815,15 +2814,15 @@ class Datagrid extends Control
 	 */
 	public function getSortableParentPath(): string
 	{
-		if ($this->getParentComponent() instanceof IPresenter) {
+		if ($this->getParentComponent() instanceof Presenter) {
 			return '';
 		}
 
-		$presenter = $this->getParentComponent()->lookupPath(IPresenter::class, false);
+		$presenter = $this->getParentComponent()->lookupPath(Presenter::class, false);
 
 		if ($presenter === null) {
 			throw new UnexpectedValueException(
-				sprintf('%s needs %s', self::class, IPresenter::class)
+				sprintf('%s needs %s', self::class, Presenter::class)
 			);
 		}
 

--- a/src/Filter/FilterMultiSelect.php
+++ b/src/Filter/FilterMultiSelect.php
@@ -57,10 +57,6 @@ class FilterMultiSelect extends FilterSelect
 		 */
 		$form = $container->lookup(Form::class);
 
-		if (!$form instanceof Form) {
-			throw new UnexpectedValueException();
-		}
-
 		$translator = $form->getTranslator();
 
 		if ($translator === null) {

--- a/src/Filter/FilterSelect.php
+++ b/src/Filter/FilterSelect.php
@@ -38,10 +38,6 @@ class FilterSelect extends OneColumnFilter
 	{
 		$form = $container->lookup(Form::class);
 
-		if (!$form instanceof Form) {
-			throw new UnexpectedValueException();
-		}
-
 		$translator = $form->getTranslator();
 
 		if ($translator === null) {


### PR DESCRIPTION
## Summary
- Use `Nette\Application\UI\Presenter` for `lookupPath()` in `Datagrid::getSortableParentPath()` — `Nette\Application\IPresenter` is just a marker interface (not an `IComponent`), so it doesn't satisfy `class-string<IComponent>`.
- Remove redundant `instanceof Form` checks in `FilterSelect` and `FilterMultiSelect` — `Container::lookup(Form::class)` already guarantees the return type via its conditional return type.

## Test plan
- [x] `make phpstan` → `[OK] No errors`