### PR TITLE
Add focused datagrid test coverage

### DIFF
--- a/src/Filter/FilterMultiSelect.php
+++ b/src/Filter/FilterMultiSelect.php
@@ -52,9 +52,7 @@ class FilterMultiSelect extends FilterSelect
 		array $options
 	): BaseControl
 	{
-		/**
-		 * Set some translated texts
-		 */
+		/** @var Form $form */
 		$form = $container->lookup(Form::class);
 
 		$translator = $form->getTranslator();

--- a/src/Filter/FilterSelect.php
+++ b/src/Filter/FilterSelect.php
@@ -36,6 +36,7 @@ class FilterSelect extends OneColumnFilter
 
 	public function addToFormContainer(Container $container): void
 	{
+		/** @var Form $form */
 		$form = $container->lookup(Form::class);
 
 		$translator = $form->getTranslator();

--- a/src/GroupAction/GroupActionCollection.php
+++ b/src/GroupAction/GroupActionCollection.php
@@ -164,11 +164,14 @@ class GroupActionCollection
 			return;
 		}
 
-		/** @var array $httpIds */
 		$httpIds = $form->getHttpData(
 			Form::DataLine | Form::DataKeys,
 			strtolower($this->datagrid->getFullName()) . '_group_action_item[]'
 		);
+
+		if (!is_array($httpIds)) {
+			$httpIds = [];
+		}
 
 		$ids = array_keys($httpIds);
 

--- a/src/InlineEdit/InlineEdit.php
+++ b/src/InlineEdit/InlineEdit.php
@@ -10,6 +10,8 @@ use Contributte\Datagrid\Traits\TButtonText;
 use Contributte\Datagrid\Traits\TButtonTitle;
 use Contributte\Datagrid\Traits\TButtonTryAddIcon;
 use Nette\Forms\Container;
+use Nette\Forms\Controls\BaseControl;
+use Nette\Forms\Controls\SubmitButton;
 use Nette\SmartObject;
 use Nette\Utils\ArrayHash;
 use Nette\Utils\Html;
@@ -178,20 +180,24 @@ class InlineEdit
 		foreach ($container->getControls() as $key => $control) {
 			switch ($key) {
 				case 'submit':
-					$control->setValidationScope([$container]);
-					$control->setAttribute('class', 'btn btn-xs btn-primary');
+					if ($control instanceof SubmitButton) {
+						$control->setValidationScope([$container]);
+						$control->setHtmlAttribute('class', 'btn btn-xs btn-primary');
+					}
 
 					break;
 
 				case 'cancel':
-					$control->setValidationScope([]);
-					$control->setAttribute('class', 'btn btn-xs btn-danger');
+					if ($control instanceof SubmitButton) {
+						$control->setValidationScope([]);
+						$control->setHtmlAttribute('class', 'btn btn-xs btn-danger');
+					}
 
 					break;
 
 				default:
-					if ($control->getControlPrototype()->getAttribute('class') === null) {
-						$control->setAttribute('class', 'form-control form-control-sm');
+					if ($control instanceof BaseControl && $control->getControlPrototype()->getAttribute('class') === null) {
+						$control->setHtmlAttribute('class', 'form-control form-control-sm');
 					}
 
 					break;

--- a/src/Utils/ItemDetailForm.php
+++ b/src/Utils/ItemDetailForm.php
@@ -15,8 +15,7 @@ final class ItemDetailForm extends Container
 	/** @var callable */
 	private $callableSetContainer;
 
-	/** @var ?array */
-	private ?array $httpPost = null;
+	private mixed $httpPost = null;
 
 	/** @var array<bool> */
 	private array $containerSetByName = [];
@@ -62,8 +61,12 @@ final class ItemDetailForm extends Container
 
 			$path = explode(self::NameSeparator, $lookupPath);
 
-			/** @var array $httpData */
 			$httpData = $form->getHttpData();
+
+			if (!is_array($httpData)) {
+				$httpData = [];
+			}
+
 			$this->httpPost = Arrays::get($httpData, $path, null);
 		}
 

--- a/tests/Cases/ColumnActionTest.phpt
+++ b/tests/Cases/ColumnActionTest.phpt
@@ -3,6 +3,7 @@
 namespace Contributte\Datagrid\Tests\Cases;
 
 use Contributte\Datagrid\Column\Action;
+use Contributte\Datagrid\Column\Action\Confirmation\CallbackConfirmation;
 use Contributte\Datagrid\Column\Action\Confirmation\StringConfirmation;
 use Contributte\Datagrid\Datagrid;
 use Contributte\Datagrid\Row;
@@ -140,6 +141,28 @@ final class ColumnActionTest extends TestCase
 
 		Assert::same(
 			'<a href="doStuff!?id=1" class="btn btn-xs btn-default btn-secondary" data-datagrid-confirm="Really?">Do</a>',
+			$this->render($action)
+		);
+	}
+
+	public function testActionConfirmPlaceholder(): void
+	{
+		$action = $this->grid->addAction('action', 'Do', 'doStuff!')
+			->setConfirmation(new StringConfirmation('Delete %s?', 'name'));
+
+		Assert::same(
+			'<a href="doStuff!?id=1" class="btn btn-xs btn-default btn-secondary" data-datagrid-confirm="Delete John?">Do</a>',
+			$this->render($action)
+		);
+	}
+
+	public function testActionConfirmCallback(): void
+	{
+		$action = $this->grid->addAction('action', 'Do', 'doStuff!')
+			->setConfirmation(new CallbackConfirmation(fn (array $item): string => 'Delete ' . $item['name'] . '?'));
+
+		Assert::same(
+			'<a href="doStuff!?id=1" class="btn btn-xs btn-default btn-secondary" data-datagrid-confirm="Delete John?">Do</a>',
 			$this->render($action)
 		);
 	}

--- a/tests/Cases/ColumnMultiActionTest.phpt
+++ b/tests/Cases/ColumnMultiActionTest.phpt
@@ -1,0 +1,89 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\Datagrid\Tests\Cases;
+
+use Contributte\Datagrid\Column\Action;
+use Contributte\Datagrid\Column\MultiAction;
+use Contributte\Datagrid\Datagrid;
+use Contributte\Datagrid\Exception\DatagridException;
+use Contributte\Datagrid\Row;
+use Contributte\Datagrid\Tests\Files\TestingDatagridFactory;
+use Tester\Assert;
+use Tester\TestCase;
+
+require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../Files/TestingDatagridFactory.php';
+
+final class ColumnMultiActionTest extends TestCase
+{
+
+	private Datagrid $grid;
+
+	public function setUp(): void
+	{
+		$factory = new TestingDatagridFactory();
+		$this->grid = $factory->createTestingDatagrid();
+	}
+
+	public function testActionRegistration(): void
+	{
+		$multiAction = new MultiAction($this->grid, 'actions', 'Actions');
+		$return = $multiAction->addAction('detail', 'Detail');
+
+		Assert::same($multiAction, $return);
+		Assert::count(1, $multiAction->getActions());
+		Assert::type(Action::class, $multiAction->getAction('detail'));
+		Assert::same(
+			'dropdown-item datagrid-multiaction-dropdown-item',
+			$multiAction->getAction('detail')->getClass(new Row($this->grid, ['id' => 1], 'id'))
+		);
+	}
+
+	public function testDuplicateActionThrowsException(): void
+	{
+		$multiAction = new MultiAction($this->grid, 'actions', 'Actions');
+		$multiAction->addAction('detail', 'Detail');
+
+		Assert::exception(
+			fn () => $multiAction->addAction('detail', 'Detail'),
+			DatagridException::class,
+			'There is already action at key [detail] defined for MultiAction.'
+		);
+	}
+
+	public function testMissingActionThrowsException(): void
+	{
+		$multiAction = new MultiAction($this->grid, 'actions', 'Actions');
+
+		Assert::exception(
+			fn () => $multiAction->getAction('missing'),
+			DatagridException::class,
+			'There is no action at key [missing] defined for MultiAction.'
+		);
+	}
+
+	public function testRowCondition(): void
+	{
+		$multiAction = new MultiAction($this->grid, 'actions', 'Actions');
+		$row = new Row($this->grid, ['id' => 1, 'enabled' => true], 'id');
+		$disabledRow = new Row($this->grid, ['id' => 2, 'enabled' => false], 'id');
+
+		Assert::true($multiAction->testRowCondition('detail', $row));
+
+		$multiAction->setRowCondition('detail', fn (array $item): bool => $item['enabled']);
+
+		Assert::true($multiAction->testRowCondition('detail', $row));
+		Assert::false($multiAction->testRowCondition('detail', $disabledRow));
+	}
+
+	public function testTemplateVariablesContainMultiAction(): void
+	{
+		$multiAction = new MultiAction($this->grid, 'actions', 'Actions');
+
+		Assert::same($multiAction, $multiAction->getTemplateVariables()['multiAction']);
+	}
+
+}
+
+
+(new ColumnMultiActionTest())->run();

--- a/tests/Cases/ColumnStatusTest.phpt
+++ b/tests/Cases/ColumnStatusTest.phpt
@@ -2,6 +2,8 @@
 
 namespace Contributte\Datagrid\Tests\Cases;
 
+use Contributte\Datagrid\Column\Action\Confirmation\CallbackConfirmation;
+use Contributte\Datagrid\Column\Action\Confirmation\StringConfirmation;
 use Contributte\Datagrid\Datagrid;
 use Contributte\Datagrid\Row;
 use Contributte\Datagrid\Tests\Files\TestingDatagridFactory;
@@ -59,6 +61,49 @@ final class ColumnStatusTest extends TestCase
 		$grid->addColumnText('test', 'Test');
 		$grid->removeColumn('test');
 		$grid->getColumnsVisibility();
+	}
+
+	public function testOptionSettersAndGetters(): void
+	{
+		$option = $this->grid->addColumnStatus('status', 'Status')
+			->addOption(1, 'Online');
+
+		Assert::same($option, $option->setTitle('Currently online'));
+		Assert::same($option, $option->setClass('btn-primary', 'btn btn-sm'));
+		Assert::same($option, $option->setClassSecondary('btn btn-secondary'));
+		Assert::same($option, $option->setClassInDropdown('dropdown-item active'));
+		Assert::same($option, $option->setIcon('check'));
+		Assert::same($option, $option->setIconSecondary('circle'));
+
+		Assert::same(1, $option->getValue());
+		Assert::same('Online', $option->getText());
+		Assert::same('Currently online', $option->getTitle());
+		Assert::same('btn-primary', $option->getClass());
+		Assert::same('btn btn-secondary', $option->getClassSecondary());
+		Assert::same('dropdown-item active', $option->getClassInDropdown());
+		Assert::same('check', $option->getIcon());
+		Assert::same('circle', $option->getIconSecondary());
+	}
+
+	public function testOptionConfirmationDialog(): void
+	{
+		$row = new Row($this->grid, ['id' => 10, 'name' => 'John'], 'id');
+		$columnStatus = $this->grid->addColumnStatus('status', 'Status');
+
+		$withoutConfirmation = $columnStatus->addOption(1, 'Online');
+		Assert::null($withoutConfirmation->getConfirmationDialog($row));
+
+		$stringConfirmation = $columnStatus->addOption(2, 'Offline')
+			->setConfirmation(new StringConfirmation('Really?'));
+		Assert::same('Really?', $stringConfirmation->getConfirmationDialog($row));
+
+		$placeholderConfirmation = $columnStatus->addOption(3, 'Blocked')
+			->setConfirmation(new StringConfirmation('Block %s?', 'name'));
+		Assert::same('Block John?', $placeholderConfirmation->getConfirmationDialog($row));
+
+		$callbackConfirmation = $columnStatus->addOption(4, 'Deleted')
+			->setConfirmation(new CallbackConfirmation(fn (array $item): string => 'Delete #' . $item['id'] . '?'));
+		Assert::same('Delete #10?', $callbackConfirmation->getConfirmationDialog($row));
 	}
 
 }

--- a/tests/Cases/DataSources/SearchParamsBuilderTest.phpt
+++ b/tests/Cases/DataSources/SearchParamsBuilderTest.phpt
@@ -184,6 +184,38 @@ final class SearchParamsBuilderTest extends TestCase
 		);
 	}
 
+	public function testEmptyBooleanMatchQueryIsSkipped(): void
+	{
+		$this->searchParamsBuilder->addBooleanMatchQuery('status', []);
+		$params = $this->searchParamsBuilder->buildParams();
+
+		Assert::same([], $params['body']['query']['bool']['must']);
+	}
+
+	public function testEmptyRangeQueryIsSkipped(): void
+	{
+		$this->searchParamsBuilder->addRangeQuery('score', null, null);
+		$params = $this->searchParamsBuilder->buildParams();
+
+		Assert::same([], $params['body']['query']['bool']['must']);
+	}
+
+	public function testOneSidedRangeQueries(): void
+	{
+		$this->searchParamsBuilder->addRangeQuery('score', 8, null);
+		$this->searchParamsBuilder->addRangeQuery('age', null, 64);
+
+		$params = $this->searchParamsBuilder->buildParams();
+
+		Assert::same(
+			[
+				['range' => ['score' => ['gte' => 8]]],
+				['range' => ['age' => ['lte' => 64]]],
+			],
+			$params['body']['query']['bool']['must']
+		);
+	}
+
 	public function testIdsQuery(): void
 	{
 		$this->searchParamsBuilder->addIdsQuery([0, 1, 1, 2, 3, 5, 8]);

--- a/tests/Cases/GroupActionTest.phpt
+++ b/tests/Cases/GroupActionTest.phpt
@@ -1,0 +1,89 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\Datagrid\Tests\Cases;
+
+use Contributte\Datagrid\Datagrid;
+use Contributte\Datagrid\Exception\DatagridGroupActionException;
+use Contributte\Datagrid\GroupAction\GroupButtonAction;
+use Contributte\Datagrid\GroupAction\GroupMultiSelectAction;
+use Contributte\Datagrid\GroupAction\GroupSelectAction;
+use Contributte\Datagrid\GroupAction\GroupTextAction;
+use Contributte\Datagrid\GroupAction\GroupTextareaAction;
+use Contributte\Datagrid\Tests\Files\TestingDatagridFactory;
+use Tester\Assert;
+use Tester\TestCase;
+
+require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../Files/TestingDatagridFactory.php';
+
+final class GroupActionTest extends TestCase
+{
+
+	private Datagrid $grid;
+
+	public function setUp(): void
+	{
+		$factory = new TestingDatagridFactory();
+		$this->grid = $factory->createTestingDatagrid();
+	}
+
+	public function testButtonActionClassDefaults(): void
+	{
+		Assert::same('btn btn-sm btn-success', (new GroupButtonAction('Delete'))->getClass());
+		Assert::same('btn btn-danger', (new GroupButtonAction('Delete', 'btn btn-danger'))->getClass());
+		Assert::same('btn btn-sm btn-success', (new GroupButtonAction('Delete', ''))->getClass());
+	}
+
+	public function testSelectActionOptions(): void
+	{
+		$empty = new GroupSelectAction('Empty');
+		$select = new GroupSelectAction('Status', ['active' => 'Active']);
+
+		Assert::false($empty->hasOptions());
+		Assert::true($select->hasOptions());
+		Assert::same(['active' => 'Active'], $select->getOptions());
+	}
+
+	public function testMultiSelectDefaultClass(): void
+	{
+		Assert::same('form-select form-select-sm selectpicker', (new GroupMultiSelectAction('Status'))->getClass());
+	}
+
+	public function testAttributesAndClassAreFluent(): void
+	{
+		$action = new GroupSelectAction('Status');
+
+		Assert::same($action, $action->setClass('form-select'));
+		Assert::same($action, $action->setAttribute('data-test', 'status'));
+		Assert::same('form-select', $action->getClass());
+		Assert::same(['data-test' => 'status'], $action->getAttributes());
+	}
+
+	public function testCollectionCreatesAndFindsActions(): void
+	{
+		$collection = $this->grid->getGroupActionCollection();
+
+		Assert::type(GroupButtonAction::class, $collection->addGroupButtonAction('Delete'));
+		Assert::type(GroupSelectAction::class, $collection->addGroupSelectAction('Status', ['active' => 'Active']));
+		Assert::type(GroupMultiSelectAction::class, $collection->addGroupMultiSelectAction('Tags', ['a' => 'A']));
+		Assert::type(GroupTextAction::class, $collection->addGroupTextAction('Message'));
+		Assert::type(GroupTextareaAction::class, $collection->addGroupTextareaAction('Note'));
+
+		Assert::same('Tags', $collection->getGroupAction('Tags')->getTitle());
+	}
+
+	public function testCollectionThrowsOnMissingAction(): void
+	{
+		$collection = $this->grid->getGroupActionCollection();
+
+		Assert::exception(
+			fn () => $collection->getGroupAction('Missing'),
+			DatagridGroupActionException::class,
+			'Group action Missing does not exist.'
+		);
+	}
+
+}
+
+
+(new GroupActionTest())->run();

--- a/tests/Cases/Utils/ArraysHelperTest.phpt
+++ b/tests/Cases/Utils/ArraysHelperTest.phpt
@@ -1,0 +1,42 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\Datagrid\Tests\Cases\Utils;
+
+use Contributte\Datagrid\Utils\ArraysHelper;
+use Tester\Assert;
+use Tester\TestCase;
+
+require __DIR__ . '/../../bootstrap.php';
+
+final class ArraysHelperTest extends TestCase
+{
+
+	public function testEmptyRecognizesNestedEmptyValues(): void
+	{
+		Assert::true(ArraysHelper::testEmpty([]));
+		Assert::true(ArraysHelper::testEmpty([null, '', [null, '']]));
+	}
+
+	public function testEmptyKeepsZeroAndFalseAsValues(): void
+	{
+		Assert::false(ArraysHelper::testEmpty([0]));
+		Assert::false(ArraysHelper::testEmpty(['0']));
+		Assert::false(ArraysHelper::testEmpty([false]));
+		Assert::false(ArraysHelper::testEmpty([[null, [false]]]));
+	}
+
+	public function testTruthyIgnoresOnlyNullAndEmptyString(): void
+	{
+		Assert::false(ArraysHelper::testTruthy([]));
+		Assert::false(ArraysHelper::testTruthy([null, '', [null, '']]));
+
+		Assert::true(ArraysHelper::testTruthy([0]));
+		Assert::true(ArraysHelper::testTruthy(['0']));
+		Assert::true(ArraysHelper::testTruthy([false]));
+		Assert::true(ArraysHelper::testTruthy([[null, [false]]]));
+	}
+
+}
+
+
+(new ArraysHelperTest())->run();

--- a/tests/Cases/Utils/DateTimeHelperTest.phpt
+++ b/tests/Cases/Utils/DateTimeHelperTest.phpt
@@ -1,0 +1,61 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\Datagrid\Tests\Cases\Utils;
+
+use Contributte\Datagrid\Exception\DatagridDateTimeHelperException;
+use Contributte\Datagrid\Utils\DateTimeHelper;
+use DateTime;
+use DateTimeImmutable;
+use DateTimeZone;
+use Tester\Assert;
+use Tester\TestCase;
+
+require __DIR__ . '/../../bootstrap.php';
+
+final class DateTimeHelperTest extends TestCase
+{
+
+	public function testReturnsDateTimeInstanceUnchanged(): void
+	{
+		$date = new DateTime('2024-01-02 03:04:05', new DateTimeZone('Europe/Prague'));
+
+		Assert::same($date, DateTimeHelper::tryConvertToDateTime($date));
+	}
+
+	public function testConvertsDateTimeImmutable(): void
+	{
+		$value = new DateTimeImmutable('2024-01-02 03:04:05', new DateTimeZone('Europe/Prague'));
+		$date = DateTimeHelper::tryConvertToDateTime($value);
+
+		Assert::type(DateTime::class, $date);
+		Assert::same('2024-01-02 03:04:05 Europe/Prague', $date->format('Y-m-d H:i:s e'));
+	}
+
+	public function testParsesDefaultFormats(): void
+	{
+		Assert::same('2024-01-02 03:04:05.123456', DateTimeHelper::fromString('2024-01-02 03:04:05.123456')->format('Y-m-d H:i:s.u'));
+		Assert::same('2024-01-02 03:04:05', DateTimeHelper::fromString('2024-01-02 03:04:05')->format('Y-m-d H:i:s'));
+		Assert::same('2024-01-02', DateTimeHelper::fromString('2024-01-02')->format('Y-m-d'));
+		Assert::same('2024-01-02 03:04:05', DateTimeHelper::fromString('2. 1. 2024 3:04:05')->format('Y-m-d H:i:s'));
+		Assert::same(123456, DateTimeHelper::fromString('123456')->getTimestamp());
+	}
+
+	public function testCustomFormatHasPriority(): void
+	{
+		$date = DateTimeHelper::tryConvertToDate('31/12/2024', ['d/m/Y']);
+
+		Assert::same('2024-12-31', $date->format('Y-m-d'));
+	}
+
+	public function testInvalidValueThrowsException(): void
+	{
+		Assert::exception(
+			fn () => DateTimeHelper::fromString('not a date'),
+			DatagridDateTimeHelperException::class
+		);
+	}
+
+}
+
+
+(new DateTimeHelperTest())->run();


### PR DESCRIPTION
## Summary

Adds focused tests for previously thinly covered datagrid helpers and action configuration paths, plus small PHPStan compatibility fixes for the current dependency set used in CI.

## Motivation

Improve regression coverage around pure utility behavior and user-facing action APIs without relying on brittle database or browser setup, while keeping CI green with freshly resolved dependencies.

## Changes

- Add tests for array and date-time helper edge cases.
- Add MultiAction and group-action unit coverage.
- Extend action and status confirmation coverage.
- Extend SearchParamsBuilder range and empty-query edge coverage.
- Tighten PHPStan-compatible source types around form/control handling.
- Rebase onto current master and keep the branch to two logical commits.

## Testing

- [x] vendor/bin/tester -s -p php --colors 1 -C tests/Cases
 _____ ___  ___ _____ ___  ___
|_   _/ __)( __/_   _/ __)| _ )
  |_| \___ /___) |_| \___ |_|_\  v2.6.0

[?25lPHP 8.5.3 (cli) | php | 8 threads

...............................s.

-- Skipped: DataSources/NextrasDataSourceTest.phpt dataprovider=mysql|/home/coder/ohmyfelix/source/contributte/datagrid/tests/Cases/DataSources/nextrasDatasource.ini
   MySQL is not running


[1m[37m[42mOK (33 tests, 1 skipped, 0.6 seconds)[0m
[?25h
- [x] vendor/bin/phpcs --standard=ruleset.xml --extensions=php,phpt --tab-width=4 --ignore=tests/tmp --colors -nsp src tests
............................................................  60 / 141 (43%)
............................................................ 120 / 141 (85%)
.....................                                        141 / 141 (100%)


Time: 3.82 secs; Memory: 30MB
- [x] vendor/bin/phpstan analyse -c phpstan.neon --memory-limit=512M

 [OK] No errors                                                                 
- [x] Latest CI passes