### PR TITLE
Přidání CSS třídy sloupce na obsahové buňky tree-view

### DIFF
--- a/src/templates/datagrid_tree.latte
+++ b/src/templates/datagrid_tree.latte
@@ -96,7 +96,7 @@
 							{foreach $columns as $key => $column}
 								{continueIf $iterator->isFirst()}
 
-								<div class="datagrid-tree-item-right-columns-column text-{$column->hasAlign() ? $column->getAlign() : 'start'}">
+								<div class="datagrid-tree-item-right-columns-column col-{$column->getColumnName()} text-{$column->hasAlign() ? $column->getAlign() : 'start'}">
 									{var $col = 'col-' . $key}
 									{php $column = $row->applyColumnCallback($key, clone $column)}
 


### PR DESCRIPTION
## Popis

V tree-view (`datagrid_tree.latte`) se na obsahové buňky pravého sloupcového bloku nepřidávala třída `col-<sloupec>`, kterou má jejich hlavička. Kvůli tomu šlo cílit CSS na konkrétní sloupec jen přes `:first-child`, `:last-child`, `:nth-child` apod.

### Příčina
Nekonzistence mezi hlavičkou a obsahem v šabloně:
- Hlavička (řádek 33): `datagrid-tree-item-right-columns-column col-{\$column->getColumnName()} text-...` → např. `col-status`
- Obsah (řádek 99): `datagrid-tree-item-right-columns-column text-...` → třída `col-status` chyběla

### Oprava
Doplněno `col-{\$column->getColumnName()}` na obsahovou buňku, takže používá stejný výraz třídy jako hlavička.

Closes #1290