### PR TITLE
Item detail form: support default values via onSetDefaults

### DIFF
--- a/.docs/actions.md
+++ b/.docs/actions.md
@@ -360,6 +360,41 @@ Datagrid user template:
 
 ```
 
+### Default values
+
+Setting a default value via `{input name, value => $item->name}` only works for controls that
+carry their value in the `value` HTML attribute (like `<input>`). It does **not** work for
+`<textarea>`, `<select>` or checkboxes, whose value is not rendered as an attribute.
+
+To set default values reliably for any control type, use the `onSetDefaults` callback. It receives
+the per-item container together with the item, so you can call `setDefaults()` on it. Defaults are
+applied only while the detail is being displayed, never over submitted values:
+
+```php
+$grid->setItemsDetailForm(function(Nette\Forms\Container $container): void {
+	$container->addTextArea('description');
+
+	$container->addSubmit('save', 'Save');
+});
+
+$grid->getItemDetailForm()->onSetDefaults[] = function(Nette\Forms\Container $container, $item): void {
+	$container->setDefaults([
+		'description' => $item->description,
+	]);
+};
+```
+
+```latte
+{block detail}
+	{formContainer items_detail_form}
+		{formContainer items_detail_form_$item->id}
+			{input description}
+			{input save}
+		{/formContainer}
+	{/formContainer}
+{/block}
+```
+
 ## Item detail template variables
 
 Additional variables can be passed to item detail template (/block) via `ItemDetail::setTemplateParameters(['foo' => 'bar', ...])`

--- a/src/Datagrid.php
+++ b/src/Datagrid.php
@@ -2435,7 +2435,7 @@ class Datagrid extends Control
 		throw new DatagridException('Please set the ItemDetail first.');
 	}
 
-	public function getItemDetailForm(): ?Container
+	public function getItemDetailForm(): ?ItemDetailForm
 	{
 		if ($this->itemsDetail instanceof ItemDetail) {
 			return $this->itemsDetail->getForm();

--- a/src/Utils/ItemDetailForm.php
+++ b/src/Utils/ItemDetailForm.php
@@ -12,6 +12,9 @@ use UnexpectedValueException;
 final class ItemDetailForm extends Container
 {
 
+	/** @var array<callable(Container, mixed): void> */
+	public array $onSetDefaults = [];
+
 	/** @var callable */
 	private $callableSetContainer;
 
@@ -19,6 +22,8 @@ final class ItemDetailForm extends Container
 
 	/** @var array<bool> */
 	private array $containerSetByName = [];
+
+	private mixed $item = null;
 
 	public function __construct(callable $callableSetContainer)
 	{
@@ -47,7 +52,14 @@ final class ItemDetailForm extends Container
 			$this->containerSetByName[$name] = true;
 		}
 
+		$this->applyDefaults($container);
+
 		return $container;
+	}
+
+	public function setItem(mixed $item): void
+	{
+		$this->item = $item;
 	}
 
 	/**
@@ -88,6 +100,21 @@ final class ItemDetailForm extends Container
 			if ((is_iterable($value))) {
 				$this->getComponentAndSetContainer($name);
 			}
+		}
+	}
+
+	private function applyDefaults(Container $container): void
+	{
+		if ($this->item === null) {
+			return;
+		}
+
+		if ($this->getForm()->isSubmitted() !== false) {
+			return;
+		}
+
+		foreach ($this->onSetDefaults as $onSetDefaults) {
+			$onSetDefaults($container, $this->item);
 		}
 	}
 

--- a/src/templates/datagrid.latte
+++ b/src/templates/datagrid.latte
@@ -329,6 +329,7 @@
 
 										{if isset($filter['items_detail_form'])}
 											{var $item_detail_params['items_detail_form'] = $filter['items_detail_form']}
+											{php $filter['items_detail_form']->setItem($item)}
 										{/if}
 
 										{ifset #detail}

--- a/tests/Cases/ItemDetailFormTest.phpt
+++ b/tests/Cases/ItemDetailFormTest.phpt
@@ -1,0 +1,86 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\Datagrid\Tests\Cases;
+
+require __DIR__ . '/../bootstrap.php';
+
+use Contributte\Datagrid\Datagrid;
+use Contributte\Datagrid\Tests\Files\TestingDatagridFactoryRouter;
+use Nette\Forms\Container;
+use Nette\Forms\Controls\TextArea;
+use Nette\Utils\ArrayHash;
+use Tester\Assert;
+use Tester\TestCase;
+
+final class ItemDetailFormTest extends TestCase
+{
+
+	/**
+	 * Regression test for https://github.com/contributte/datagrid/issues/962
+	 *
+	 * A textarea inside the item detail form cannot receive its value via the
+	 * {input name, value => ...} attribute (that only works for <input>). The
+	 * onSetDefaults callback sets the actual control value, so it works for any
+	 * control type.
+	 */
+	public function testOnSetDefaultsFillsTextArea(): void
+	{
+		$factory = new TestingDatagridFactoryRouter();
+		/** @var Datagrid $grid */
+		$grid = $factory->createTestingDatagrid()->getComponent('grid');
+
+		$grid->setItemsDetail();
+		$grid->setItemsDetailForm(function (Container $container): void {
+			$container->addTextArea('description');
+		});
+
+		$itemDetailForm = $grid->getItemDetailForm();
+		Assert::notNull($itemDetailForm);
+
+		$itemDetailForm->onSetDefaults[] = function (Container $container, $item): void {
+			$container->setDefaults([
+				'description' => $item->description,
+			]);
+		};
+
+		$form = $grid->createComponentFilter();
+
+		$item = ArrayHash::from(['id' => 1, 'description' => 'Lorem ipsum']);
+		$form['items_detail_form']->setItem($item);
+
+		$container = $form['items_detail_form']['items_detail_form_1'];
+		Assert::type(Container::class, $container);
+
+		$description = $container['description'];
+		Assert::type(TextArea::class, $description);
+		Assert::same('Lorem ipsum', $description->getValue());
+	}
+
+	public function testWithoutItemDefaultsAreNotApplied(): void
+	{
+		$factory = new TestingDatagridFactoryRouter();
+		/** @var Datagrid $grid */
+		$grid = $factory->createTestingDatagrid()->getComponent('grid');
+
+		$grid->setItemsDetail();
+		$grid->setItemsDetailForm(function (Container $container): void {
+			$container->addTextArea('description');
+		});
+
+		$itemDetailForm = $grid->getItemDetailForm();
+		Assert::notNull($itemDetailForm);
+
+		$itemDetailForm->onSetDefaults[] = function (Container $container, $item): void {
+			$container['description']->setValue('should not appear');
+		};
+
+		$form = $grid->createComponentFilter();
+
+		// No setItem() call — defaults must not be applied, controls stay empty.
+		$container = $form['items_detail_form']['items_detail_form_1'];
+		Assert::same('', $container['description']->getValue());
+	}
+
+}
+
+(new ItemDetailFormTest())->run();


### PR DESCRIPTION
Closes #962

## Problem

It was impossible to set a default value for a `<textarea>` (or `<select>`, checkboxes) inside `setItemsDetailForm()`. The documented approach `{input name, value => $item->name}` only works for `<input>`, because it renders the value as an HTML `value` attribute. A `<textarea>` takes its value from the control value (`TextArea::getControl()` → `setText()`), not from a `value` attribute, so it stayed empty. The build callback also received only the `Container`, without the item, so `setDefaultValue()` could not be called with per-row data.

## Solution

Mirror the existing `InlineEdit` pattern (`onControlAdd` + `onSetDefaults`). The item detail form now exposes an `onSetDefaults` hook that receives `(Container $container, $item)` and lets you set the real control values via `setDefaults()` — working for any control type. Defaults are applied only while the detail is being displayed and never over submitted values.

```php
$grid->setItemsDetailForm(function (Container $container): void {
    $container->addTextArea('description');
    $container->addSubmit('save', 'Save');
});

$grid->getItemDetailForm()->onSetDefaults[] = function (Container $container, $item): void {
    $container->setDefaults(['description' => $item->description]);
};
```

## Changes

- `ItemDetailForm`: add public `onSetDefaults`, `setItem()` and a private `applyDefaults()` guarded by "item is set and form is not submitted".
- `datagrid.latte`: call `setItem($item)` before rendering the `#detail` block.
- `Datagrid::getItemDetailForm()`: return type narrowed `?Container` → `?ItemDetailForm` so `->onSetDefaults[]` type-checks.
- Docs: new "Default values" subsection explaining the `value` attribute limitation and the `onSetDefaults` usage.
- Tests: new `ItemDetailFormTest` (textarea gets its default value; defaults are not applied without an item).

Backward compatible — behaviour is unchanged when `onSetDefaults` is not used. PHPStan, PHPCS and the test suite all pass.