### PR TITLE
Oprava PHPStan chyby instanceof.alwaysTrue u Presenter::getRequest()

### DIFF
--- a/src/Datagrid.php
+++ b/src/Datagrid.php
@@ -47,7 +47,6 @@ use DateTimeInterface;
 use InvalidArgumentException;
 use Nette\Application\Attributes\Persistent;
 use Nette\Application\ForbiddenRequestException;
-use Nette\Application\Request;
 use Nette\Application\UI\Component;
 use Nette\Application\UI\Control;
 use Nette\Application\UI\Form;
@@ -1948,10 +1947,6 @@ class Datagrid extends Control
 	{
 		$column = $this->getColumn($key);
 		$request = $this->getPresenterInstance()->getRequest();
-
-		if (!$request instanceof Request) {
-			throw new UnexpectedValueException();
-		}
 
 		$value = $request->getPost('value');
 


### PR DESCRIPTION
## Problem

The PHPStan CI job (which runs `composer update` → latest dependencies) fails on `master`:

```
Instanceof between Nette\Application\Request and Nette\Application\Request will always evaluate to true.
 src/Datagrid.php:1952  instanceof.alwaysTrue
```

Since **nette/application v3.3.0**, `Presenter::getRequest()` returns a non-nullable `Nette\Application\Request` (previously `?Request`). The defensive `instanceof Request` guard in `handleEdit()` therefore becomes always-true and PHPStan reports it.

This is unrelated to any feature work — it is pure dependency drift and reproduces on a clean `master` (verified locally with `nette/application` upgraded to `v3.3.0`).

## Fix

`handleEdit()` is a signal handler (`handle*`), so `getPresenterInstance()->getRequest()` is always set while it runs — it can never be `null` there. The `instanceof Request` guard was dead defensive code left over from when `getRequest()` was typed `?Request`. It is removed, along with the now-unused `use Nette\Application\Request;` import.

## Verification

- `make phpstan` passes with `nette/application v3.3.0` installed (the version CI resolves).
- Full test suite passes (33 tests, 1 skipped — MySQL not running locally).
