### PR TITLE
Fix inline editing second-edit stale value (#948)

### DIFF
--- a/assets/plugins/features/editable.ts
+++ b/assets/plugins/features/editable.ts
@@ -93,6 +93,12 @@ export class EditablePlugin implements DatagridPlugin {
 									}
 									cell.innerHTML = value;
 								}
+
+								// Keep the editable value in sync with the submitted value so
+								// that a subsequent edit starts from the current value, not the
+								// one rendered on initial page load (see issue #948).
+								cell.setAttribute(EditableValueAttribute, el.value);
+
 								cell.classList.add("edited");
 							} catch {
 								cell.innerHTML = originalValue;


### PR DESCRIPTION
## Problem

When a column uses `setEditableValueCallback()` together with inline editing, the first edit works correctly, but a **second edit of the same cell shows the value from before the first edit**.

Reported in #948.

### Root cause

On render, the cell stores the raw editable value in the `data-datagrid-editable-value` attribute, while `innerHTML` holds the rendered representation. The client reads `valueToEdit` from that attribute.

After a successful edit, the client updates only `innerHTML` (to `_datagrid_editable_new_value`), but **never updates the `data-datagrid-editable-value` attribute**. So the next edit reads the stale value captured on the initial page load.

## Fix

After a successful inline edit, sync `data-datagrid-editable-value` with the submitted input value, so subsequent edits start from the current value. Applies to both text/textarea and select inputs.

Purely client-side (`assets/plugins/features/editable.ts`); no server round-trip needed since the submitted raw value is already available on the client.

Closes #948